### PR TITLE
qmake5_paths: correct headers path to use ${QT_DIR_NAME} as postifx

### DIFF
--- a/classes/qmake5_paths.bbclass
+++ b/classes/qmake5_paths.bbclass
@@ -3,7 +3,7 @@
 # to your distro layer and flatten all QT_DIR_NAME directories
 
 OE_QMAKE_PATH_PREFIX = "${prefix}"
-OE_QMAKE_PATH_HEADERS = "${includedir}"
+OE_QMAKE_PATH_HEADERS = "${includedir}/${QT_DIR_NAME}"
 OE_QMAKE_PATH_LIBS = "${libdir}"
 OE_QMAKE_PATH_ARCHDATA = "${libdir}"
 OE_QMAKE_PATH_DATA = "${datadir}"


### PR DESCRIPTION
Signed-off-by: Simon Busch morphis@gravedo.de
