### PR TITLE
Update SRC_URI to point to archived 5.0.2

### DIFF
--- a/recipes-qt/qt5/qt5-5.0.2.inc
+++ b/recipes-qt/qt5/qt5-5.0.2.inc
@@ -7,7 +7,7 @@ QT_VERSION ?= "${PV}"
 QT_VERSION_DIR ?= "${QT_VERSION}"
 
 SRC_URI += " \
-    http://releases.qt-project.org/qt5/${QT_VERSION_DIR}/submodules/${QT_MODULE}-opensource-src-${QT_VERSION}.tar.xz \
+    http://releases.qt-project.org/archive/qt/5.0/${QT_VERSION_DIR}/submodules/${QT_MODULE}-opensource-src-${QT_VERSION}.tar.xz \
 "
 
 S = "${WORKDIR}/${QT_MODULE}-opensource-src-${QT_VERSION}"


### PR DESCRIPTION
5.0.2 sources have now been moved to archive directory
on http://releases.qt-project.org/archive/qt/5.0/5.0.2/.
