### PR TITLE
Added recipe for qtquickcontrols.

### DIFF
--- a/conf/distro/include/qt5-versions.inc
+++ b/conf/distro/include/qt5-versions.inc
@@ -12,6 +12,8 @@ PREFERRED_VERSION_qtgraphicaleffects = "${QT5_VERSION}"
 PREFERRED_VERSION_qtimageformats = "${QT5_VERSION}"
 PREFERRED_VERSION_qtmultimedia = "${QT5_VERSION}"
 PREFERRED_VERSION_qtquick1 = "${QT5_VERSION}"
+# NOTE: qtquickcontrols is not supported with 5.0.2
+PREFERRED_VERSION_qtquickcontrols = "${QT5_VERSION}"
 PREFERRED_VERSION_qtsensors = "${QT5_VERSION}"
 PREFERRED_VERSION_qtscript = "${QT5_VERSION}"
 PREFERRED_VERSION_qtsvg = "${QT5_VERSION}"

--- a/recipes-qt/qt5/qt5.inc
+++ b/recipes-qt/qt5/qt5.inc
@@ -56,6 +56,11 @@ FILES_${PN}-qmlplugins = " \
     ${OE_QMAKE_PATH_QML}/*/*/*/*.qmltypes \
     ${OE_QMAKE_PATH_QML}/*/*/*/*.qml \
     ${OE_QMAKE_PATH_QML}/*/*/*/*.js \
+    ${OE_QMAKE_PATH_QML}/*/*/*/*/*${SOLIBSDEV} \
+    ${OE_QMAKE_PATH_QML}/*/*/*/*/qmldir \
+    ${OE_QMAKE_PATH_QML}/*/*/*/*/*.qmltypes \
+    ${OE_QMAKE_PATH_QML}/*/*/*/*/*.qml \
+    ${OE_QMAKE_PATH_QML}/*/*/*/*/*.js \
     ${OE_QMAKE_PATH_IMPORTS}/*.qmltypes \
     ${OE_QMAKE_PATH_IMPORTS}/*/*${SOLIBSDEV} \
     ${OE_QMAKE_PATH_IMPORTS}/*/*.qmltypes \

--- a/recipes-qt/qt5/qtbase.inc
+++ b/recipes-qt/qt5/qtbase.inc
@@ -52,6 +52,8 @@ PACKAGECONFIG ??= " \
     evdev \
     widgets \
     openssl \
+    # accessibility is required to compile qtquickcontrols. uncomment if needed \
+    # accessibility \
     ${PACKAGECONFIG_GL} \
     ${PACKAGECONFIG_FB} \
     ${PACKAGECONFIG_X11} \

--- a/recipes-qt/qt5/qtquickcontrols.inc
+++ b/recipes-qt/qt5/qtquickcontrols.inc
@@ -1,0 +1,7 @@
+require qt5.inc
+
+FILES_${PN}-qmlplugins += " \
+   ${OE_QMAKE_PATH_QML}/*/*/*/*/*/*.png \
+"
+
+DEPENDS += "qtscript"

--- a/recipes-qt/qt5/qtquickcontrols_5.1.0.bb
+++ b/recipes-qt/qt5/qtquickcontrols_5.1.0.bb
@@ -1,0 +1,5 @@
+require qt5-${PV}.inc
+require ${PN}.inc
+
+SRC_URI[md5sum] = "b3825124a173a36f63c2f8380dc61e81"
+SRC_URI[sha256sum] = "88d39421d78464c3900c37616e8369fc8d998c1b0f611980e6e082f46569646b"

--- a/recipes-qt/qt5/qtquickcontrols_git.bb
+++ b/recipes-qt/qt5/qtquickcontrols_git.bb
@@ -1,0 +1,4 @@
+require qt5-git.inc
+require ${PN}.inc
+
+SRCREV = "c304d741a27b5822a35d1fb83f8f5e65719907ce"


### PR DESCRIPTION
Enabled accessibility in qtbase, since qtquickcontrols needs it, and
since the configure script of qtbase says that disabling accessibility
is not recommended.
