### PR TITLE
Adding a check to make the staging isn't trying to copy from itself

### DIFF
--- a/classes/qmake5_base.bbclass
+++ b/classes/qmake5_base.bbclass
@@ -171,7 +171,7 @@ qmake5_base_do_install() {
     # but we cannot remove sysroot override, because that's useful for pkg-config etc
     # In some cases like QtQmlDevTools in qtdeclarative, the sed above does not work,
     # fix them manually
-    if [ -d ${D}${STAGING_DIR_TARGET} ] ; then
+    if [ -d ${D}${STAGING_DIR_TARGET} ] && [ -n "${STAGING_DIR_TARGET}" ] ; then
         echo "Some files are installed in wrong directory ${D}${STAGING_DIR_TARGET}"
         cp -ra ${D}${STAGING_DIR_TARGET}/* ${D}
         rm -rf ${D}${STAGING_DIR_TARGET}


### PR DESCRIPTION
I would like to submit this pull request to fix an instance where the system will try to copy files into itself(${D} directory) if the ${STAGING_DIR_TARGET} variable is empty.
