### PR TITLE
qmake4_base.bbclass: Add staging directory for native builds

### DIFF
--- a/classes/qmake5_base.bbclass
+++ b/classes/qmake5_base.bbclass
@@ -171,7 +171,7 @@ qmake5_base_do_install() {
     # but we cannot remove sysroot override, because that's useful for pkg-config etc
     # In some cases like QtQmlDevTools in qtdeclarative, the sed above does not work,
     # fix them manually
-    if [ -d ${D}${STAGING_DIR_TARGET} ] ; then
+    if [ -d ${D}${STAGING_DIR_TARGET} ] && [ -n "${STAGING_DIR_TARGET}" ] ; then
         echo "Some files are installed in wrong directory ${D}${STAGING_DIR_TARGET}"
         cp -ra ${D}${STAGING_DIR_TARGET}/* ${D}
         rm -rf ${D}${STAGING_DIR_TARGET}


### PR DESCRIPTION
When building a basic Qt5 native application, the build fails on the do_install task as a result of the  variable being empty. This causes the copy command in the test block to fail because it is trying to copy files from/to itself.
