### PR TITLE
cinematicexperience: fix qt5.3 compatibility

### DIFF
--- a/recipes-qt/examples/cinematicexperience/fix_qt5_3_compatibility.patch
+++ b/recipes-qt/examples/cinematicexperience/fix_qt5_3_compatibility.patch
@@ -1,0 +1,48 @@
+Index: Qt5_CinematicExperience_rpi_1.0/content/SettingsView.qml
+===================================================================
+--- Qt5_CinematicExperience_rpi_1.0.orig/content/SettingsView.qml
++++ Qt5_CinematicExperience_rpi_1.0/content/SettingsView.qml
+@@ -127,8 +127,8 @@ Item {
+             Switch {
+                 text: "Do you l-o-v-e colors?"
+                 checked: settings.showColors
+-                onText: "Yes"
+-                offText: "No!"
++                textON: "Yes"
++                textOFF: "No!"
+                 onCheckedChanged: {
+                     settings.showColors = checked;
+                 }
+Index: Qt5_CinematicExperience_rpi_1.0/content/Switch.qml
+===================================================================
+--- Qt5_CinematicExperience_rpi_1.0.orig/content/Switch.qml
++++ Qt5_CinematicExperience_rpi_1.0/content/Switch.qml
+@@ -6,8 +6,8 @@ Item {
+ 
+     property alias text: textItem.text
+     property bool checked: false
+-    property string onText: "On"
+-    property string offText: "Off"
++    property string textON: "On"
++    property string textOFF: "Off"
+ 
+     QtObject {
+         id: priv
+@@ -120,7 +120,7 @@ Item {
+             color: "#000000"
+             font.pixelSize: 18
+             font.bold: true
+-            text: onText
++            text: textON
+         }
+         Text {
+             anchors.verticalCenter: parent.verticalCenter
+@@ -129,7 +129,7 @@ Item {
+             color: "#ffffff"
+             font.pixelSize: 18
+             font.bold: true
+-            text: offText
++            text: textOFF
+         }
+ 
+         Image {

--- a/recipes-qt/examples/cinematicexperience_1.0.bb
+++ b/recipes-qt/examples/cinematicexperience_1.0.bb
@@ -5,6 +5,7 @@ LICENSE = "CC-BY-3.0"
 LIC_FILES_CHKSUM = "file://README;beginline=38;endline=50;md5=51babd597624b70752069953876aaa18"
 
 SRC_URI = "http://quitcoding.com/download/Qt5_CinematicExperience_rpi_1.0.tgz"
+SRC_URI += "file://fix_qt5_3_compatibility.patch"
 
 SRC_URI[md5sum] = "935a5db0a6b2a72c67236e72f52be7d1"
 SRC_URI[sha256sum] = "0dd602983ced5f7c0cfd5ad0fbfe2b0b7e3c9ff715e4ef23eef818ccc2b6c60b"


### PR DESCRIPTION
cinematicexperience will run failed on Qt5.3 and Qt5.3.1, error message
as below

---

Qt5_CinematicExperience.qml:26:5: Type MainView unavailable
         MainView {
         ^
/content/MainView.qml:241:9: Type SettingsView unavailable
             SettingsView {
             ^
/content/SettingsView.qml:88:13: Type Switch unavailable
                 Switch {
                 ^
/content/Switch.qml:9:21: Cannot assign a value to a signal (expecting a script to be run)
         property string onText: "On"

```
                     ^
```

---

This patch fix this issue and make cinematicexperience can run on qt5.3.

ref: http://wickwire2099.blogspot.tw/2014/05/qt-530-qt5-cinematic-experience.html

Signed-off-by: coldnew coldnew.tw@gmail.com
