### PR TITLE
qtwebengine: build examples by default

### DIFF
--- a/recipes-qt/qt5/qtwebengine/0001-examples-enable-building-examples-by-def.patch
+++ b/recipes-qt/qt5/qtwebengine/0001-examples-enable-building-examples-by-def.patch
@@ -1,0 +1,7 @@
+--- a/qtwebengine.pro	2016-01-04 02:08:57.152198023 +0000
++++ b/qtwebengine.pro	2016-01-04 02:09:11.667422022 +0000
+@@ -1,2 +1,4 @@
+ load(qt_build_config)
+ load(qt_parts)
++
++SUBDIRS += examples

--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -115,6 +115,7 @@ SRC_URI += " \
     file://0002-media_capture_devices_dispatcher.h-Include-QCoreApplication-translate.patch \
     file://0003-WebEngine-qquickwebengineview_p_p.h-add-inc-QColor.patch \
     file://0001-chromium-jpeg_codec.cc_Change-false-to-FALSE-and-1-to-TRUE.patch \
+    file://0001-examples-enable-building-examples-by-def.patch \
 "
 
 SRCREV_qtwebengine = "40ef43e0d69c4a86c9430b7f264d2cde6340ee0f"


### PR DESCRIPTION
Just as we do for qtwebkit, let us have a patch to build
qtwebengine examples by default.

Otherwise, the "qtwebengine-examples" package will be
empty, and attempting to add it with "IMAGE_INSTALL_append"
will result in an error message.

Signed-off-by: Manuel Bachmann <manuel.bachmann@iot.bzh>