### PR TITLE
libofono: Don't assume qml files will be installed under ${libdir}/qt5

### DIFF
--- a/recipes-connectivity/libqofono/libqofono_git.bb
+++ b/recipes-connectivity/libqofono/libqofono_git.bb
@@ -23,15 +23,15 @@ PACKAGES += "${PN}-tests"
 
 FILES_${PN}-dbg += " \
     /lib/libqofono-qt5/tests/.debug \
-    ${libdir}/qt5/qml/MeeGo/QOfono/.debug \
+    ${QE_QMAKE_PATH_QML}/MeeGo/QOfono/.debug \
 "
 FILES_${PN}-tests = " \
     ${libdir}/libqofono-qt5/tests/tst_* \
     /opt/tests/libqofono-qt5 \
 "
 FILES_${PN} += " \
-    ${libdir}/qt5/qml/MeeGo/QOfono/qmldir \
-    ${libdir}/qt5/qml/MeeGo/QOfono/libQOfonoQtDeclarative.so \
+    ${OE_QMAKE_PATH_QML}/MeeGo/QOfono/qmldir \
+    ${OE_QMAKE_PATH_QML}/MeeGo/QOfono/libQOfonoQtDeclarative.so \
 "
 FILES_${PN}-dev += " \
     ${datadir}/qt5/mkspecs \


### PR DESCRIPTION
This assumption will fail in case the user has set QT_DIR_NAME. Using
OE_QMAKE_PATH_QML should always work properly.

Signed-off-by: Piotr Tworek <tworaz@tworaz.net>