### PR TITLE
libconnman-qt5: Upgrade to latest upstream version 1.1.8

### DIFF
--- a/recipes-connectivity/libconnman-qt/libconnman-qt5_git.bb
+++ b/recipes-connectivity/libconnman-qt/libconnman-qt5_git.bb
@@ -5,11 +5,11 @@ HOMEPAGE = "https://git.merproject.org/mer-core/libconnman-qt"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://libconnman-qt/clockmodel.h;endline=8;md5=ea9f724050803f15d2d900ce3c5dac88"
 DEPENDS += "qtbase qtdeclarative"
-PV = "1.0.98+git${SRCPV}"
+PV = "1.1.8+git${SRCPV}"
 
-SRCREV = "8d4580a55ca02b84fc3db374c6530e39c94e0d92"
+SRCREV = "a6e37fca8177924656331c23a5a3f5d3c7c179b9"
 SRC_URI = "git://git.merproject.org/mer-core/libconnman-qt.git;protocol=https \
-    file://0001-Don-t-use-MeeGo-as-prefix-in-order-to-make-this-a-co.patch \
+           file://0001-Don-t-use-MeeGo-as-prefix-in-order-to-make-this-a-co.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Signed-off-by: Piotr Tworek <tworaz@tworaz.net>