### PR TITLE
qtvirtualkeyboard: Make sure qmlplugin package pulls in the im plugin.

### DIFF
--- a/recipes-qt/qt5/qtvirtualkeyboard_git.bb
+++ b/recipes-qt/qt5/qtvirtualkeyboard_git.bb
@@ -44,6 +44,7 @@ EXTRA_QMAKEVARS_PRE += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'CONF
 
 PACKAGES += "${PN}-dictionaries"
 RRECOMMENDS_${PN} += "${PN}-dictionaries"
+RDEPENDS_${PN}-qmlplugins += "${PN}-plugins"
 FILES_${PN}-dictionaries = "${OE_QMAKE_PATH_DATA}/qtvirtualkeyboard/*/*.dat"
 FILES_${PN} += "${OE_QMAKE_PATH_DATA}/qtvirtualkeyboard/lipi_toolkit"
 


### PR DESCRIPTION
The problem can be observed when using kwin from meta-qt5-extra. It
reports QtQuick.VirtualKeyboard import failure even though
qtvirtualkeyboard-qmlplugin is installed. The reason for that is the
QML plugin is not usable by itself. It needs the Qt IM plugin to
load succesfully.
    
Signed-off-by: Piotr Tworek <tworaz@tworaz.net>
