### PR TITLE
qtbase: fix Krogoth build regression from efa8aaf

### DIFF
--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -94,7 +94,7 @@ OE_QMAKE_PATH_HOST_LIBS = "${libdir}"
 
 # for qtbase configuration we need default settings
 # since we cannot set empty set filename to a not existent file
-export OE_QMAKE_QTCONF_PATH = "foodummy"
+deltask generate_qt_config_file
 
 do_configure() {
     ${S}/configure -v \

--- a/recipes-qt/qt5/qtbase-native_git.bb
+++ b/recipes-qt/qt5/qtbase-native_git.bb
@@ -79,7 +79,7 @@ PACKAGECONFIG_CONFARGS = " \
 
 # for qtbase configuration we need default settings
 # since we cannot set empty set filename to a not existent file
-export OE_QMAKE_QTCONF_PATH = "foodummy"
+deltask generate_qt_config_file
 
 do_configure_prepend() {
     # Avoid qmake error "Cannot read [...]/usr/lib/qt5/mkspecs/oe-device-extra.pri: No such file or directory"

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -137,7 +137,7 @@ QT_CONFIG_FLAGS += " \
 
 # for qtbase configuration we need default settings
 # since we cannot set empty set filename to a not existent file
-export OE_QMAKE_QTCONF_PATH = "foodummy"
+deltask generate_qt_config_file
 
 do_configure() {
     # Avoid qmake error "Cannot read [...]/usr/lib/qt5/mkspecs/oe-device-extra.pri: No such file or directory" during configuration


### PR DESCRIPTION
With

    commit efa8aaf82e580a7d32eaaab48eb92d436f2e222a
    Author: Andreas Müller <schnitzeltony@googlemail.com>
    Date:   Thu Feb  9 00:26:09 2017

    qmake5_base.bbclass: set qt.conf by environment variable again

we stopped pointing ${OE_QMAKE_QTCONF_PATH} at a valid file and
instead directed it to a path which was intended not to exist.

The motivation was to permit qtbase/qtbase-native/nativesdk-qtbase
to build again after Qt 5.8 started paying attention to the
contents of this file.

The change as done in efa8aaf works well enough for Morty and
subsequent releases' copies of Bitbake, but fails on earlier
releases because they lack the following change:

    commit 2afcbfef2cd1ca568e5225884a8021df38ee3db0
    Author: Ross Burton <ross.burton@intel.com>
    Date: 2016-07-14 13:56:22

    bitbake: build: don't use $B as the default cwd for functions

The result is that when we build with Krogoth or prior, the body
of do_generate_qt_config_file() runs with a cwd of ${B}, which was
_not_ the intent of efa8aaf. Because the working directory is ${B},
${OE_QMAKE_QTCONF_PATH} is written in there too. do_configure() --
whose cwd is by design also ${B} -- then finds the file 'foodummy',
and the build breaks for the reasons outlined in efa8aaf.

This change simply shifts the implementation tactics to suppress
the creation of ${OE_QMAKE_QTCONF_PATH} during qtbase rather than rely
on unspecified behavior about the cwd of do_generate_qt_config_file().

(cherry picked from commit a17ff281aa8d99f770b0a049cb798235005fb93e
at https://codereview.qt-project.org/yocto/meta-qt5.)