### PR TITLE
qt5: Add recipe for qtpurchasing.

### DIFF
--- a/recipes-qt/qt5/qtpurchasing_git.bb
+++ b/recipes-qt/qt5/qtpurchasing_git.bb
@@ -1,0 +1,13 @@
+require qt5.inc
+require qt5-git.inc
+
+HOMEPAGE = "http://www.qt.io"
+LICENSE = "Apache-2.0 & BSD & ( LGPL-3.0 | GPL-3.0 | The-Qt-Company-Commercial )"
+LIC_FILES_CHKSUM = " \
+    file://LICENSE.LGPLv3;md5=b8c75190712063cde04e1f41b6fdad98 \
+    file://LICENSE.GPLv3;md5=40f9bf30e783ddc201497165dfb32afb \
+"
+
+DEPENDS += "qtbase qtdeclarative"
+
+SRCREV = "49c5461af0888950b80eb9558647ccd764d55737"


### PR DESCRIPTION
Qt Purchasing was introduced as a new module in Qt 5.7 (previously only available with Qt's commercial license). It can be used to build payment features, as was done in the late Ubuntu Phone project. 

The commit hash is the latest in the 5.10 branch. Licenses were combed with licensecheck tool. 