### PR TITLE
qttranslations: fix QA issue about unshipped files

### DIFF
--- a/recipes-qt/qt5/qttranslations_git.bb
+++ b/recipes-qt/qt5/qttranslations_git.bb
@@ -8,6 +8,10 @@ LIC_FILES_CHKSUM = " \
 
 DEPENDS += "qtbase qttools-native"
 
+do_install_append() {
+    find "${D}/${OE_QMAKE_PATH_TRANSLATIONS}" -type f -name "qtconfig_*.qm" -exec rm -f {} \;
+}
+
 PACKAGES =. " \
     ${PN}-assistant \
     ${PN}-designer \


### PR DESCRIPTION
Previously in commit 8124b3c768f8e539d6cbe670d6caca132415f435
"[...]qttranslations: fix nothing provides qttranslations-qtconfig",
the package qttranslations-qtconfig has been removed from the recipe.
But apparently, the current version of qttranslations still includes
artifacts which are not associated with any package anymore, resulting
in the following QA issue:

  ERROR: QA Issue: qttranslations:
  Files/directories were installed but not shipped in any package:
    /usr/share/qt5/translations/qtconfig_sk.qm
    /usr/share/qt5/translations/qtconfig_uk.qm
    /usr/share/qt5/translations/qtconfig_ko.qm
    /usr/share/qt5/translations/qtconfig_hu.qm
    /usr/share/qt5/translations/qtconfig_sl.qm
    /usr/share/qt5/translations/qtconfig_ja.qm
    /usr/share/qt5/translations/qtconfig_zh_CN.qm
    /usr/share/qt5/translations/qtconfig_ru.qm
    /usr/share/qt5/translations/qtconfig_pl.qm
    /usr/share/qt5/translations/qtconfig_zh_TW.qm
  Please set FILES such that these items are packaged.
  Alternatively if they are unneeded, avoid installing them
  or delete them within do_install.
  qttranslations: 10 installed and not shipped files.
  [installed-vs-shipped]

These files are now removed in the do_install()-task.

Signed-off-by: Dennis Menschel <menschel-d@posteo.de>

---
These changes correspond to the following patch which has not been merged yet:
https://patchwork.openembedded.org/patch/151787/