### PR TITLE
[sumo] qtbase-mkspecs: fix runtime dependency on python

### DIFF
--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -176,8 +176,8 @@ do_install() {
     install -m 644 ${WORKDIR}/OEQt5Toolchain.cmake ${D}${datadir}/cmake/OEToolchainConfig.cmake.d/
 
     # Fix up absolute paths in scripts
-    grep -lr /usr/bin/python ${D}${OE_QMAKE_PATH_QT_ARCHDATA}/ | \
-        xargs -r sed -i -e '1s,#!.*python,#! ${USRBINPATH}/env python,'
+    sed -i -e '1s,#!/usr/bin/python,#! ${USRBINPATH}/env python,' \
+        ${D}${OE_QMAKE_PATH_QT_ARCHDATA}/mkspecs/features/uikit/devices.py
 }
 
 fakeroot do_generate_qt_environment_file() {

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -237,6 +237,10 @@ do_install_append() {
     echo "isEmpty(QMAKE_STRIP): QMAKE_STRIP = ${TARGET_PREFIX}strip" >> $conf
 
     generate_target_qt_config_file ${D}${OE_QMAKE_PATH_BINS}/qt.conf
+
+    # Fix up absolute paths in scripts
+    sed -i -e '1s,#!/usr/bin/python,#! ${USRBINPATH}/env python,' \
+        ${D}${OE_QMAKE_PATH_QT_ARCHDATA}/mkspecs/features/uikit/devices.py
 }
 
 # mkspecs have mac specific scripts that depend on perl and bash


### PR DESCRIPTION
When running the task "do_populate_sdk()" for an image inheriting from
"populate_sdk_qt5.bbclass", the following error could be observed in
case PACKAGE_CLASSES included "package_rpm":

  ERROR: Could not invoke dnf.
  [...]
  Error:
   Problem: package packagegroup-qt5-toolchain-target-1.0-r0.noarch
            requires qtbase-mkspecs, but none of the providers can be
            installed
    - conflicting requests
    - nothing provides /usr/bin/python needed by
      qtbase-mkspecs-5.10.1+git0+6c6ace9d23-r0.armv5e

The script file in question that requires python to run is located at
"/usr/lib/qt5/mkspecs/features/uikit/devices.py".

Signed-off-by: Dennis Menschel <menschel-d@posteo.de>

---
The changes have been tested with `MACHINE = "qemuarm"` and an extended `core-image-minimal` that inherits from `populate_sdk_qt5.bbclass`.