### PR TITLE
qt5/qtscript: Fix qtscript cross compile error

### DIFF
--- a/recipes-qt/qt5/qtscript/0001-javascriptcore-Use-64-bit-ints.patch
+++ b/recipes-qt/qt5/qtscript/0001-javascriptcore-Use-64-bit-ints.patch
@@ -1,0 +1,58 @@
+From 8fd53951d53ef8c5b62fe985665dad0545bb3161 Mon Sep 17 00:00:00 2001
+From: Alistair Francis <alistair.francis@wdc.com>
+Date: Mon, 4 Jun 2018 14:24:59 -0700
+Subject: [PATCH] javascriptcore: Use 64-bit ints
+
+Where required use 64-bit integers for casts.
+
+Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
+Upstream-Status: Pending
+---
+ .../JavaScriptCore/assembler/X86Assembler.h               | 2 +-
+ .../javascriptcore/JavaScriptCore/runtime/JSValue.h       | 8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/3rdparty/javascriptcore/JavaScriptCore/assembler/X86Assembler.h b/src/3rdparty/javascriptcore/JavaScriptCore/assembler/X86Assembler.h
+index ab3d05f..ed5965f 100644
+--- a/src/3rdparty/javascriptcore/JavaScriptCore/assembler/X86Assembler.h
++++ b/src/3rdparty/javascriptcore/JavaScriptCore/assembler/X86Assembler.h
+@@ -2033,7 +2033,7 @@ private:
+             }
+         }
+ 
+-#if !CPU(X86_64)
++#if CPU(X86)
+         void memoryModRM(int reg, void* address)
+         {
+             // noBase + ModRmMemoryNoDisp means noBase + ModRmMemoryDisp32!
+diff --git a/src/3rdparty/javascriptcore/JavaScriptCore/runtime/JSValue.h b/src/3rdparty/javascriptcore/JavaScriptCore/runtime/JSValue.h
+index 7584c52..958ac89 100644
+--- a/src/3rdparty/javascriptcore/JavaScriptCore/runtime/JSValue.h
++++ b/src/3rdparty/javascriptcore/JavaScriptCore/runtime/JSValue.h
+@@ -490,7 +490,11 @@ namespace JSC {
+             u.asBits.tag = CellTag;
+         else
+             u.asBits.tag = EmptyValueTag;
++#if CPU(X86)
+         u.asBits.payload = reinterpret_cast<int32_t>(ptr);
++#else
++        u.asBits.payload = reinterpret_cast<int64_t>(ptr);
++#endif
+ #if ENABLE(JSC_ZOMBIES)
+         ASSERT(!isZombie());
+ #endif
+@@ -502,7 +506,11 @@ namespace JSC {
+             u.asBits.tag = CellTag;
+         else
+             u.asBits.tag = EmptyValueTag;
++#if CPU(X86)
+         u.asBits.payload = reinterpret_cast<int32_t>(const_cast<JSCell*>(ptr));
++#else
++        u.asBits.payload = reinterpret_cast<int64_t>(const_cast<JSCell*>(ptr));
++#endif
+ #if ENABLE(JSC_ZOMBIES)
+         ASSERT(!isZombie());
+ #endif
+-- 
+2.17.1
+

--- a/recipes-qt/qt5/qtscript_git.bb
+++ b/recipes-qt/qt5/qtscript_git.bb
@@ -11,6 +11,8 @@ LIC_FILES_CHKSUM = " \
     file://LICENSE.LGPL3;md5=e6a600fd5e1d9cbde2d983680233ad02 \
 "
 
+SRC_URI += "file://0001-javascriptcore-Use-64-bit-ints.patch"
+
 # qemuarm build fails with:
 # /OE/build/oe-core/tmp-glibc/work/armv5te-oe-linux-gnueabi/qtscript/5.4.1+gitAUTOINC+822df36f25-r0/git/src/3rdparty/javascriptcore/JavaScriptCore/assembler/AssemblerBuffer.h: In member function 'void QTJSC::AssemblerBuffer::putInt64Unchecked(int64_t)':
 #/OE/build/oe-core/tmp-glibc/work/armv5te-oe-linux-gnueabi/qtscript/5.4.1+gitAUTOINC+822df36f25-r0/git/src/3rdparty/javascriptcore/JavaScriptCore/assembler/AssemblerBuffer.h:106:58: warning: cast from 'char*' to 'int64_t* {aka long long int*}' increases required alignment of target type [-Wcast-align]


### PR DESCRIPTION
Fix errors like this:
error: cast from 'QTJSC::JSCell*' to 'int32_t' {aka 'int'} loses precision
when cross compiling for RISC-V.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>