### PR TITLE
qt5: add option to build Qt5 statically

### DIFF
--- a/recipes-qt/qt5/qt5.inc
+++ b/recipes-qt/qt5/qt5.inc
@@ -37,6 +37,14 @@ python __anonymous() {
             d.setVar("PACKAGE_ARCH", tarch)
 }
 
+# if building static Qt5, add qtdeclarative-native dependency to all recipes
+# that depend on qtdeclarative as it's required for qmlimportscannertool
+python __anonymous() {
+    if bb.utils.contains('DISTRO_FEATURES', "qt5-static", True, False, d):
+        if bb.utils.contains('DEPENDS', "qtdeclarative", True, False, d):
+            d.appendVar("DEPENDS", " qtdeclarative-native")
+}
+
 # Many examples come with libraries installed outside of standard libdir,
 # suppress QA check complaining
 INSANE_SKIP_${PN}-dbg += "libdir"
@@ -48,6 +56,8 @@ PACKAGES =. "${PN}-qmlplugins-dbg ${PN}-tools-dbg ${PN}-plugins-dbg ${PN}-qmldes
 
 ALLOW_EMPTY_${PN} = "1"
 ALLOW_EMPTY_${PN}-dbg = "1"
+ALLOW_EMPTY_${PN}-plugins = "1"
+ALLOW_EMPTY_${PN}-qmlplugins = "1"
 
 RRECOMMENDS_${PN} = " \
     ${PN}-plugins \
@@ -159,6 +169,18 @@ FILES_${PN}-dbg += " \
 "
 FILES_${PN}-staticdev += " \
     ${OE_QMAKE_PATH_LIBS}/*.a \
+    ${OE_QMAKE_PATH_PLUGINS}/*/*.a \
+    ${OE_QMAKE_PATH_PLUGINS}/*/*.prl \
+    ${OE_QMAKE_PATH_PLUGINS}/*/*/*.a \
+    ${OE_QMAKE_PATH_PLUGINS}/*/*/*.prl \
+    ${OE_QMAKE_PATH_QML}/*/*.a \
+    ${OE_QMAKE_PATH_QML}/*/*.prl \
+    ${OE_QMAKE_PATH_QML}/*/*/*.a \
+    ${OE_QMAKE_PATH_QML}/*/*/*.prl \
+    ${OE_QMAKE_PATH_QML}/*/*/*/*.a \
+    ${OE_QMAKE_PATH_QML}/*/*/*/*.prl \
+    ${OE_QMAKE_PATH_QML}/*/*/*/*/*.a \
+    ${OE_QMAKE_PATH_QML}/*/*/*/*/*.prl \
 "
 FILES_${PN}-examples = " \
     ${OE_QMAKE_PATH_EXAMPLES}/* \

--- a/recipes-qt/qt5/qtbase/0001-Add-linux-oe-g-platform.patch
+++ b/recipes-qt/qt5/qtbase/0001-Add-linux-oe-g-platform.patch
@@ -22,10 +22,11 @@ Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
 ---
  configure                            |  2 +-
  mkspecs/features/configure.prf       |  4 +--
+ mkspecs/features/qt.prf              |  6 ++--
  mkspecs/features/qt_functions.prf    |  2 +-
  mkspecs/linux-oe-g++/qmake.conf      | 42 ++++++++++++++++++++++++++++
  mkspecs/linux-oe-g++/qplatformdefs.h |  1 +
- 5 files changed, 47 insertions(+), 4 deletions(-)
+ 6 files changed, 50 insertions(+), 7 deletions(-)
  create mode 100644 mkspecs/linux-oe-g++/qmake.conf
  create mode 100644 mkspecs/linux-oe-g++/qplatformdefs.h
 
@@ -63,6 +64,30 @@ index 934a18a924..0f5b1b6333 100644
              log("yes$$escape_expand(\\n)")
              msg = "test $$1 succeeded"
              write_file($$QMAKE_CONFIG_LOG, msg, append)
+diff --git a/mkspecs/features/qt.prf b/mkspecs/features/qt.prf
+index b57afcf72d..afa1c39b3e 100644
+--- a/mkspecs/features/qt.prf
++++ b/mkspecs/features/qt.prf
+@@ -147,7 +147,7 @@ import_plugins:qtConfig(static) {
+         !isEmpty(plug_type) {
+             plug_path = $$eval(QT_PLUGIN.$${plug}.PATH)
+             isEmpty(plug_path): \
+-                plug_path = $$[QT_INSTALL_PLUGINS/get]
++                plug_path = $$[QT_INSTALL_PLUGINS]
+             LIBS += -L$$plug_path/$$plug_type
+         }
+         LIBS += -l$${plug}$$qtPlatformTargetSuffix()
+@@ -298,8 +298,8 @@ for(ever) {
+ # static builds: link qml import plugins into the target.
+ contains(all_qt_module_deps, qml): \
+         qtConfig(static):import_plugins:!host_build:!no_import_scan {
+-    exists($$[QT_INSTALL_QML/get]): \
+-        QMLPATHS *= $$[QT_INSTALL_QML/get]
++    exists($$[QT_INSTALL_QML]): \
++        QMLPATHS *= $$[QT_INSTALL_QML]
+ 
+     # run qmlimportscanner
+     qtPrepareTool(QMLIMPORTSCANNER, qmlimportscanner, , system)
 diff --git a/mkspecs/features/qt_functions.prf b/mkspecs/features/qt_functions.prf
 index 1903e509c8..c093dd4592 100644
 --- a/mkspecs/features/qt_functions.prf

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -70,6 +70,7 @@ PACKAGECONFIG_RELEASE ?= "release"
 # PACKAGECONFIG_OPENSSL ?= "openssl"
 PACKAGECONFIG_DEFAULT ?= "dbus udev evdev widgets tools libs freetype tests \
     ${@bb.utils.contains('SELECTED_OPTIMIZATION', '-Os', 'optimize-size ltcg', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'qt5-static', 'static', '', d)} \
 "
 
 PACKAGECONFIG ?= " \
@@ -84,6 +85,7 @@ PACKAGECONFIG ?= " \
     ${PACKAGECONFIG_DISTRO} \
 "
 
+PACKAGECONFIG[static] = "-static,-shared"
 PACKAGECONFIG[release] = "-release,-debug"
 PACKAGECONFIG[debug] = ""
 PACKAGECONFIG[developer] = "-developer-build"

--- a/recipes-qt/qt5/qtdeclarative_git.bb
+++ b/recipes-qt/qt5/qtdeclarative_git.bb
@@ -14,10 +14,11 @@ LIC_FILES_CHKSUM = " \
 
 DEPENDS += "qtbase"
 
-PACKAGECONFIG ??= "qtxmlpatterns qml-debug qml-network"
+PACKAGECONFIG ??= "qtxmlpatterns qml-debug qml-network ${@bb.utils.contains('DISTRO_FEATURES', 'qt5-static', 'static', '', d)}"
 PACKAGECONFIG[qtxmlpatterns] = ",,qtxmlpatterns"
 PACKAGECONFIG[qml-debug] = "-qml-debug,-no-qml-debug"
 PACKAGECONFIG[qml-network] = "-qml-network, -no-qml-network"
+PACKAGECONFIG[static] = ",,qtdeclarative-native"
 
 do_configure_prepend() {
     # disable qtxmlpatterns test if it isn't enabled by PACKAGECONFIG

--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -73,6 +73,10 @@ inherit qmake5
 inherit gettext
 inherit pythonnative
 inherit perlnative
+inherit distro_features_check
+
+# Static builds of QtWebEngine aren't supported.
+CONFLICT_DISTRO_FEATURES = "qt5-static"
 
 # we don't want gettext.bbclass to append --enable-nls
 def gettext_oeconf(d):


### PR DESCRIPTION
Add PACKAGECONFIG that enables static build for qtbase and consequently
to all Qt recipes. This can be enabled with DISTRO_FEATURE 'qt5-static',
which also adds qtdeclarative-native dependency to all recipes that
depend on qtdeclarative as it's required for qmlimportscannertool.

Building examples and tests with static build can take excessive amounts
of time and disk space, so disabling DISTRO_FEATURE 'ptest' and
PACKAGECONFIGs 'examples' from qtbase is advised.

Not all recipes support static builds and those are not fixed here.

Signed-off-by: Samuli Piippo <samuli.piippo@qt.io>