### PR TITLE
qttools: Disable clang support

### DIFF
--- a/recipes-qt/qt5/qttools_git.bb
+++ b/recipes-qt/qt5/qttools_git.bb
@@ -27,7 +27,10 @@ FILES_${PN}-examples = "${datadir}${QT_DIR_NAME}/examples"
 PACKAGECONFIG ??= ""
 PACKAGECONFIG[qtwebkit] = ",,qtwebkit"
 
-EXTRA_QMAKEVARS_PRE += "${@bb.utils.contains('PACKAGECONFIG', 'qtwebkit', '', 'CONFIG+=noqtwebkit', d)}"
+EXTRA_QMAKEVARS_PRE += " \
+    CONFIG-=config_clang \
+    ${@bb.utils.contains('PACKAGECONFIG', 'qtwebkit', '', 'CONFIG+=noqtwebkit', d)} \
+"
 
 SRCREV = "a01f3629377f25506d523406d2b93ffbff711a51"
 


### PR DESCRIPTION
If host has clang installed, the qdoc is enabled doing host
contamination. For now, we disable this completely.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>