### PR TITLE
qtbase: don't pass empty filename to function

### DIFF
--- a/recipes-qt/qt5/qtbase/0003-qlibraryinfo-allow-to-set-qt.conf-from-the-outside-u.patch
+++ b/recipes-qt/qt5/qtbase/0003-qlibraryinfo-allow-to-set-qt.conf-from-the-outside-u.patch
@@ -29,7 +29,7 @@ index b4ba0b5..11d4c00 100644
 -    QString qtconfig = qmake_libraryInfoFile();
 +    QByteArray config = getenv("OE_QMAKE_QTCONF_PATH");
 +    QString qtconfig = QFile::decodeName(config);
-+    if(!QFile::exists(qtconfig))
++    if(qtconfig.isEmpty() || !QFile::exists(qtconfig))
 +        qtconfig = qmake_libraryInfoFile();
      if (QFile::exists(qtconfig))
          return new QSettings(qtconfig, QSettings::IniFormat);


### PR DESCRIPTION
The same warning is present on the sumo branch, let us silent it :-)

The environment variable is empty when running qmake from SDK or
in device, which gives 'Empty filename passed to function' warning.

Signed-off-by: Samuli Piippo <samuli.piippo@qt.io>
Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
(cherry picked from commit 65db89eb7b6a9b53f7877d6e16bc4deeb367c285)