### PR TITLE
packagegroup-qt5-toolchain-target: Remove non-existing qttranslations…

### DIFF
--- a/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bb
+++ b/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bb
@@ -36,7 +36,6 @@ RDEPENDS_${PN} += " \
     qtbase-mkspecs \
     qtbase-plugins \
     qtbase-staticdev \
-    qttranslations-qt \
     qttranslations-qtbase \
     qttranslations-qthelp \
     qtcharts-dev \


### PR DESCRIPTION
…-qt from rdeps

Fixes
ERROR: Nothing RPROVIDES 'qttranslations-qt' (but /home/jenkins/oe/world/oe-build/sources/meta-qt5/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bb RDEPENDS on or otherwise requires it)
NOTE: Runtime target 'qttranslations-qt' is unbuildable, removing...

Signed-off-by: Khem Raj <raj.khem@gmail.com>