### PR TITLE
nativesdk-packagegroup-qt5-toolchain-host: Add perl modules

### DIFF
--- a/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
+++ b/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
@@ -11,4 +11,5 @@ RDEPENDS_${PN} += " \
     nativesdk-packagegroup-sdk-host \
     nativesdk-qttools-tools \
     nativesdk-qtbase-tools \
+    nativesdk-perl-modules \
 "


### PR DESCRIPTION
perl modules are needed for syncqt.pl 