### PR TITLE
qtbase: fix runtime error with older kernels

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -151,8 +151,21 @@ PACKAGECONFIG[libinput] = "-libinput,-no-libinput,libinput"
 PACKAGECONFIG[journald] = "-journald,-no-journald,systemd"
 
 QT_CONFIG_FLAGS_GOLD = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', '-use-gold-linker', '-no-use-gold-linker', d)}"
+
+def if_kernel_older_than(d, version, older_flag):
+    if bb.utils.vercmp_string(d.getVar('OLDEST_KERNEL'), version) < 0:
+        return older_flag
+    else:
+        return ''
+
+QT_CONFIG_FLAGS_KERNEL = " \
+    ${@if_kernel_older_than(d, '3.16', '-no-feature-renameat2')} \
+    ${@if_kernel_older_than(d, '3.17', '-no-feature-getentropy')} \
+"
+
 QT_CONFIG_FLAGS += " \
     ${QT_CONFIG_FLAGS_GOLD} \
+    ${QT_CONFIG_FLAGS_KERNEL} \
     -shared \
     -silent \
     -no-pch \


### PR DESCRIPTION
When running with an older kernel we need to pass some extra flags
to configure to make sure it doesn't build a binary that expects
syscalls that are then not supported on machine kernel.

This patch add a check for renameat2 introduced in 3.16 and getentropy
introduced in 3.17.

Signed-off-by: Alban Bedel <alban.bedel@avionic-design.de>