### PR TITLE
qtwebengine: add a package config to enable proprietary codecs

### DIFF
--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -58,6 +58,7 @@ PACKAGECONFIG[protobuf] = "-feature-webengine-system-protobuf,-no-feature-webeng
 PACKAGECONFIG[jasoncpp] = "-feature-webengine-system-jsoncpp,-no-feature-webengine-system-jsoncpp,jasoncpp"
 PACKAGECONFIG[libxml2] = "-feature-webengine-system-libxml2,-no-feature-webengine-system-libxml2,libxml2"
 PACKAGECONFIG[minizip] = "-feature-webengine-system-minizip,-no-feature-webengine-system-minizip,minizip"
+PACKAGECONFIG[proprietary-codecs] = "-feature-webengine-proprietary-codecs,-no-feature-webengine-proprietary-codecs"
 
 EXTRA_QMAKEVARS_CONFIGURE += "${PACKAGECONFIG_CONFARGS}"
 


### PR DESCRIPTION
Add a package config that allow to enable proprietary codecs for h264
support.

Signed-off-by: Alban Bedel <alban.bedel@avionic-design.de>