### PR TITLE
qtbase: Add packageconfigs for renameat2 and getentropy use

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -149,6 +149,10 @@ PACKAGECONFIG[widgets] = "-widgets,-no-widgets"
 PACKAGECONFIG[libproxy] = "-libproxy,-no-libproxy,libproxy"
 PACKAGECONFIG[libinput] = "-libinput,-no-libinput,libinput"
 PACKAGECONFIG[journald] = "-journald,-no-journald,systemd"
+# needs kernel 3.16+
+PACKAGECONFIG[renameat2] = "-feature-renameat2,-no-feature-renameat2,"
+# needs kernel 3.17+
+PACKAGECONFIG[getentropy] = "-feature-getentropy,-no-feature-getentropy,"
 
 QT_CONFIG_FLAGS_GOLD = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', '-use-gold-linker', '-no-use-gold-linker', d)}"
 QT_CONFIG_FLAGS += " \


### PR DESCRIPTION
These features depend on underlying syscall support in kernel
and if older kernels are in use, then we can have a knob to
turn them off.

Signed-off-by: Khem Raj <raj.khem@gmail.com>
Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
Signed-off-by: Alban Bedel <alban.bedel@avionic-design.de>
(cherry picked from commit 1ac92b6d8a7e1e1395929c87465e347789961086)