### PR TITLE
qtwebkit_git.bb: Fix configure failure on bison

### DIFF
--- a/recipes-qt/qt5/qtwebkit_git.bb
+++ b/recipes-qt/qt5/qtwebkit_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = " \
     file://Source/JavaScriptCore/parser/Parser.h;endline=21;md5=bd69f72183a7af673863f057576e21ee \
 "
 
-DEPENDS += "qtbase qtdeclarative icu ruby-native sqlite3 glib-2.0 libxslt gperf-native"
+DEPENDS += "qtbase qtdeclarative icu ruby-native sqlite3 glib-2.0 libxslt gperf-native bison-native"
 
 inherit cmake_qt5 perlnative pythonnative
 


### PR DESCRIPTION
Fix the following error during do_configure

| CMake Error at
|   Could NOT find BISON (missing: BISON_EXECUTABLE) (Required is at
least
|   version "2.1")
| Call Stack (most recent call first):

Add dependency to bison-native to fix the above error

Signed-off-by: Manjukumar Matha <manjukumar.harthikote-matha@xilinx.com>