### PR TITLE
qtwebengine: enable debug info for webengine

### DIFF
--- a/recipes-qt/qt5/qtbase/0001-Add-linux-oe-g-platform.patch
+++ b/recipes-qt/qt5/qtbase/0001-Add-linux-oe-g-platform.patch
@@ -1,4 +1,4 @@
-From a0a36aaaeb0509d5964566f501b717d2dd27b205 Mon Sep 17 00:00:00 2001
+From 542b69b5534214e9d0ddb4ba328325d0bfcccb50 Mon Sep 17 00:00:00 2001
 From: Martin Jansa <Martin.Jansa@gmail.com>
 Date: Mon, 15 Apr 2013 04:29:32 +0200
 Subject: [PATCH] Add linux-oe-g++ platform
@@ -22,10 +22,11 @@ Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
 ---
  configure                            |  2 +-
  mkspecs/features/configure.prf       |  4 +--
+ mkspecs/features/qt.prf              |  6 ++---
  mkspecs/features/qt_functions.prf    |  2 +-
  mkspecs/linux-oe-g++/qmake.conf      | 40 ++++++++++++++++++++++++++++
  mkspecs/linux-oe-g++/qplatformdefs.h |  1 +
- 5 files changed, 45 insertions(+), 4 deletions(-)
+ 6 files changed, 48 insertions(+), 7 deletions(-)
  create mode 100644 mkspecs/linux-oe-g++/qmake.conf
  create mode 100644 mkspecs/linux-oe-g++/qplatformdefs.h
 
@@ -63,6 +64,30 @@ index 934a18a9249..0f5b1b63334 100644
              log("yes$$escape_expand(\\n)")
              msg = "test $$1 succeeded"
              write_file($$QMAKE_CONFIG_LOG, msg, append)
+diff --git a/mkspecs/features/qt.prf b/mkspecs/features/qt.prf
+index b57afcf72d7..afa1c39b3e9 100644
+--- a/mkspecs/features/qt.prf
++++ b/mkspecs/features/qt.prf
+@@ -147,7 +147,7 @@ import_plugins:qtConfig(static) {
+         !isEmpty(plug_type) {
+             plug_path = $$eval(QT_PLUGIN.$${plug}.PATH)
+             isEmpty(plug_path): \
+-                plug_path = $$[QT_INSTALL_PLUGINS/get]
++                plug_path = $$[QT_INSTALL_PLUGINS]
+             LIBS += -L$$plug_path/$$plug_type
+         }
+         LIBS += -l$${plug}$$qtPlatformTargetSuffix()
+@@ -298,8 +298,8 @@ for(ever) {
+ # static builds: link qml import plugins into the target.
+ contains(all_qt_module_deps, qml): \
+         qtConfig(static):import_plugins:!host_build:!no_import_scan {
+-    exists($$[QT_INSTALL_QML/get]): \
+-        QMLPATHS *= $$[QT_INSTALL_QML/get]
++    exists($$[QT_INSTALL_QML]): \
++        QMLPATHS *= $$[QT_INSTALL_QML]
+ 
+     # run qmlimportscanner
+     qtPrepareTool(QMLIMPORTSCANNER, qmlimportscanner, , system)
 diff --git a/mkspecs/features/qt_functions.prf b/mkspecs/features/qt_functions.prf
 index 1903e509c8e..c093dd4592d 100644
 --- a/mkspecs/features/qt_functions.prf

--- a/recipes-qt/qt5/qtbase/0001-Add-linux-oe-g-platform.patch
+++ b/recipes-qt/qt5/qtbase/0001-Add-linux-oe-g-platform.patch
@@ -1,4 +1,4 @@
-From bb416ea80d421c53012e13280d68bdcefc815b8f Mon Sep 17 00:00:00 2001
+From a0a36aaaeb0509d5964566f501b717d2dd27b205 Mon Sep 17 00:00:00 2001
 From: Martin Jansa <Martin.Jansa@gmail.com>
 Date: Mon, 15 Apr 2013 04:29:32 +0200
 Subject: [PATCH] Add linux-oe-g++ platform
@@ -23,14 +23,14 @@ Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
  configure                            |  2 +-
  mkspecs/features/configure.prf       |  4 +--
  mkspecs/features/qt_functions.prf    |  2 +-
- mkspecs/linux-oe-g++/qmake.conf      | 42 ++++++++++++++++++++++++++++
+ mkspecs/linux-oe-g++/qmake.conf      | 40 ++++++++++++++++++++++++++++
  mkspecs/linux-oe-g++/qplatformdefs.h |  1 +
- 5 files changed, 47 insertions(+), 4 deletions(-)
+ 5 files changed, 45 insertions(+), 4 deletions(-)
  create mode 100644 mkspecs/linux-oe-g++/qmake.conf
  create mode 100644 mkspecs/linux-oe-g++/qplatformdefs.h
 
 diff --git a/configure b/configure
-index 2830a1b189..6445dc2d5a 100755
+index 2830a1b1897..6445dc2d5a0 100755
 --- a/configure
 +++ b/configure
 @@ -712,7 +712,7 @@ fi
@@ -43,7 +43,7 @@ index 2830a1b189..6445dc2d5a 100755
  
  # build qmake
 diff --git a/mkspecs/features/configure.prf b/mkspecs/features/configure.prf
-index 934a18a924..0f5b1b6333 100644
+index 934a18a9249..0f5b1b63334 100644
 --- a/mkspecs/features/configure.prf
 +++ b/mkspecs/features/configure.prf
 @@ -46,14 +46,14 @@ defineTest(qtCompileTest) {
@@ -64,7 +64,7 @@ index 934a18a924..0f5b1b6333 100644
              msg = "test $$1 succeeded"
              write_file($$QMAKE_CONFIG_LOG, msg, append)
 diff --git a/mkspecs/features/qt_functions.prf b/mkspecs/features/qt_functions.prf
-index 1903e509c8..c093dd4592 100644
+index 1903e509c8e..c093dd4592d 100644
 --- a/mkspecs/features/qt_functions.prf
 +++ b/mkspecs/features/qt_functions.prf
 @@ -69,7 +69,7 @@ defineTest(qtHaveModule) {
@@ -78,10 +78,10 @@ index 1903e509c8..c093dd4592 100644
              cmd = perl -w $$system_path($${cmd}.pl)
 diff --git a/mkspecs/linux-oe-g++/qmake.conf b/mkspecs/linux-oe-g++/qmake.conf
 new file mode 100644
-index 0000000000..30d31ed16d
+index 00000000000..d90dfeb4482
 --- /dev/null
 +++ b/mkspecs/linux-oe-g++/qmake.conf
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,40 @@
 +#
 +# qmake configuration for linux-g++ with modifications for building with OpenEmbedded
 +#
@@ -110,8 +110,6 @@ index 0000000000..30d31ed16d
 +QMAKE_CC       = $$(OE_QMAKE_CC)
 +QMAKE_CXX      = $$(OE_QMAKE_CXX)
 +
-+QMAKE_CFLAGS_RELEASE_WITH_DEBUGINFO += $$(OE_QMAKE_CFLAGS)
-+
 +QMAKE_LINK         = $$(OE_QMAKE_LINK)
 +QMAKE_LINK_SHLIB   = $$(OE_QMAKE_LINK)
 +QMAKE_LINK_C       = $$(OE_QMAKE_LINK)
@@ -126,7 +124,7 @@ index 0000000000..30d31ed16d
 +load(qt_config)
 diff --git a/mkspecs/linux-oe-g++/qplatformdefs.h b/mkspecs/linux-oe-g++/qplatformdefs.h
 new file mode 100644
-index 0000000000..5d22fb4101
+index 00000000000..5d22fb41013
 --- /dev/null
 +++ b/mkspecs/linux-oe-g++/qplatformdefs.h
 @@ -0,0 +1 @@

--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -31,6 +31,7 @@ DEPENDS += " \
 DEPENDS_append_libc-musl = " libexecinfo"
 
 EXTRA_QMAKEVARS_CONFIGURE += "-feature-webengine-system-ninja -no-feature-webengine-system-gn"
+EXTRA_QMAKEVARS_PRE += "CONFIG+=force_debug_info"
 
 # chromium/third_party/openh264/openh264.gyp adds
 # -Wno-format to openh264_cflags_add


### PR DESCRIPTION
Enable debug info for webengine builds. The mkspec needed fixing,
otherwise CFLAGS were fed incorrectly to Ninja.

Signed-off-by: Samuli Piippo <samuli.piippo@qt.io>