### PR TITLE
qtwebengine: use nasm instead of yasm

### DIFF
--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -17,7 +17,7 @@ DEPENDS += " \
     nss-native \
     nspr-native \
     ninja-native \
-    yasm-native \
+    nasm-native \
     bison-native \
     qtwebchannel \
     qtbase qtdeclarative qtxmlpatterns qtquickcontrols qtquickcontrols2 \


### PR DESCRIPTION
With the removal of yasm from OE-core
(OE-Core rev: b7f3f7ecfdf26129c5df2d3ee14e73c4633ea5a3),
use nasm-native instead of yasm-native close to
"gstreamer1.0-libav: use nasm instead of yasm"
(OE-Core rev: 9343c02cc12aa210a1b7ae7696c83a5501c91ceb)

Signed-off-by: Jens Rehsack <sno@netbsd.org>