### PR TITLE
nativesdk-qtbase: fix packaging QA issue

### DIFF
--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -59,6 +59,7 @@ PACKAGE_DEBUG_SPLIT_STYLE = "debug-without-src"
 FILES_${PN}-dev += " \
     ${OE_QMAKE_PATH_ARCHDATA}/mkspecs \
     ${OE_QMAKE_PATH_LIBS}/*.prl \
+    ${datadir}/cmake \
 "
 
 FILES_${PN} += " \


### PR DESCRIPTION
nativesdk-qtbase_git.bb had a line removed in commit "3224b02
nativesdk-qtbase: use default PACKAGES" that causes following error:

  ERROR: nativesdk-qtbase-5.11.2+gitAUTOINC+b0dce506cc-r0 do_package: QA Issue: nativesdk-qtbase:
  Files/directories were installed but not shipped in any package:
  /opt/poky/2.3.4/sysroots/x86_64-pokysdk-linux/usr/share
  /opt/poky/2.3.4/sysroots/x86_64-pokysdk-linux/usr/share/cmake
  /opt/poky/2.3.4/sysroots/x86_64-pokysdk-linux/usr/share/cmake/OEToolchainConfig.cmake.d
  /opt/poky/2.3.4/sysroots/x86_64-pokysdk-linux/usr/share/cmake/OEToolchainConfig.cmake.d/OEQt5Toolchain.cmake

Undo the line removal causing the QA issue.

Signed-off-by: Mikko Gronoff <mikko.gronoff@qt.io>