### PR TITLE
qt5: Disable ltcg for host_build

### DIFF
--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -40,6 +40,7 @@ SRC_URI += "\
     file://0013-Upgrade-double-conversion-to-v3.0.0.patch \
     file://0014-Check-glibc-version-for-renameat2-statx-on-non-boots.patch \
     file://0015-double-conversion-support-AARCH64EB-and-arm-BE.patch \
+    file://0016-Disable-ltcg-for-host_build.patch \
 "
 
 # common for qtbase-native and nativesdk-qtbase

--- a/recipes-qt/qt5/qtbase-native_git.bb
+++ b/recipes-qt/qt5/qtbase-native_git.bb
@@ -35,6 +35,7 @@ SRC_URI += "\
     file://0013-Upgrade-double-conversion-to-v3.0.0.patch \
     file://0014-Check-glibc-version-for-renameat2-statx-on-non-boots.patch \
     file://0015-double-conversion-support-AARCH64EB-and-arm-BE.patch \
+    file://0016-Disable-ltcg-for-host_build.patch \
 "
 
 # common for qtbase-native and nativesdk-qtbase

--- a/recipes-qt/qt5/qtbase/0016-Disable-ltcg-for-host_build.patch
+++ b/recipes-qt/qt5/qtbase/0016-Disable-ltcg-for-host_build.patch
@@ -1,0 +1,26 @@
+From 94383531bde019ba113cc416b5cf3627e18ffef3 Mon Sep 17 00:00:00 2001
+From: Samuli Piippo <samuli.piippo@qt.io>
+Date: Tue, 23 Oct 2018 09:54:57 +0300
+Subject: [PATCH] Disable ltcg for host_build
+
+debug-prefix-map does not work correctly for static libraries
+when using ltcg, and since host_build compilations link agaist
+the libQt5Bootstrap.a library, it breaks source file packaging
+into debug packages.
+
+Task-number: QTBUG-71230
+Upstream-Status: Inappropriate [embedded specific]
+---
+ mkspecs/features/ltcg.prf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mkspecs/features/ltcg.prf b/mkspecs/features/ltcg.prf
+index ccf0226272..482e5b573d 100644
+--- a/mkspecs/features/ltcg.prf
++++ b/mkspecs/features/ltcg.prf
+@@ -1,4 +1,4 @@
+-CONFIG(release, debug|release) {
++CONFIG(release, debug|release):!host_build {
+     # We need fat object files when creating static libraries on some platforms
+     # so the linker will know to load a particular object from the library
+     # in the first place. On others, we have special ar and nm to create the symbol

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -31,6 +31,7 @@ SRC_URI += "\
     file://0013-Upgrade-double-conversion-to-v3.0.0.patch \
     file://0014-Check-glibc-version-for-renameat2-statx-on-non-boots.patch \
     file://0015-double-conversion-support-AARCH64EB-and-arm-BE.patch \
+    file://0016-Disable-ltcg-for-host_build.patch \
 "
 
 


### PR DESCRIPTION
debug-prefix-map does not work correctly for static libraries
when using ltcg, and since host_build compilations link agaist
the libQt5Bootstrap.a library, it breaks source file packaging
into debug packages.

Signed-off-by: Samuli Piippo <samuli.piippo@qt.io>