### PR TITLE
qtbase: don't leak absolut path to recipe specific sysroot

### DIFF
--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -40,6 +40,7 @@ SRC_URI += "\
     file://0013-Upgrade-double-conversion-to-v3.0.0.patch \
     file://0014-Check-glibc-version-for-renameat2-statx-on-non-boots.patch \
     file://0015-double-conversion-support-AARCH64EB-and-arm-BE.patch \
+    file://0001-Qt5GuiConfigExtras.cmake.in-cope-with-variable-path-.patch \
 "
 
 # common for qtbase-native and nativesdk-qtbase

--- a/recipes-qt/qt5/qtbase-native_git.bb
+++ b/recipes-qt/qt5/qtbase-native_git.bb
@@ -35,6 +35,7 @@ SRC_URI += "\
     file://0013-Upgrade-double-conversion-to-v3.0.0.patch \
     file://0014-Check-glibc-version-for-renameat2-statx-on-non-boots.patch \
     file://0015-double-conversion-support-AARCH64EB-and-arm-BE.patch \
+    file://0001-Qt5GuiConfigExtras.cmake.in-cope-with-variable-path-.patch \
 "
 
 # common for qtbase-native and nativesdk-qtbase

--- a/recipes-qt/qt5/qtbase/0001-Qt5GuiConfigExtras.cmake.in-cope-with-variable-path-.patch
+++ b/recipes-qt/qt5/qtbase/0001-Qt5GuiConfigExtras.cmake.in-cope-with-variable-path-.patch
@@ -1,0 +1,69 @@
+From cc017da9bb6936c6e147e8d416c8405493d4422c Mon Sep 17 00:00:00 2001
+From: Max Krummenacher <max.krummenacher@toradex.com>
+Date: Sat, 27 Oct 2018 12:29:31 +0000
+Subject: [PATCH] Qt5GuiConfigExtras.cmake.in: cope with variable path to
+ sysroot
+
+EGL is configured to need an include path into the recipe-specific sysroot.
+However users of the cmake file will have a different absolute path than that
+used when creating the cmake file from cmake.in in qtbase.
+
+Change to store the relative path within the sysroot and then prepend the
+currently used sysroot in the _qt5gui_find_extra_libs macro.
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>
+---
+ src/gui/Qt5GuiConfigExtras.cmake.in | 22 ++++++++--------------
+ 1 file changed, 8 insertions(+), 14 deletions(-)
+
+diff --git a/src/gui/Qt5GuiConfigExtras.cmake.in b/src/gui/Qt5GuiConfigExtras.cmake.in
+index 07869efd7d..671aa82167 100644
+--- a/src/gui/Qt5GuiConfigExtras.cmake.in
++++ b/src/gui/Qt5GuiConfigExtras.cmake.in
+@@ -75,21 +75,15 @@ unset(_qt5gui_OPENGL_INCLUDE_DIR CACHE)
+ 
+ macro(_qt5gui_find_extra_libs Name Libs LibDir IncDirs)
+     set(Qt5Gui_${Name}_LIBRARIES)
+-!!IF !mac
+-    set(Qt5Gui_${Name}_INCLUDE_DIRS ${IncDirs})
+-!!ELSE
++
+     foreach(_dir ${IncDirs})
+-      if (EXISTS ${_dir})
+-        list(APPEND Qt5Gui_${Name}_INCLUDE_DIRS ${_dir})
+-      else()
+-        find_path(_actual_dir ${_dir}) # Look in sdk directories
+-        if (_actual_dir)
+-          list(APPEND Qt5Gui_${Name}_INCLUDE_DIRS ${_actual_dir})
+-        endif()
+-        unset(_actual_dir CACHE)
++      find_path(_actual_dir ${_dir})
++      if (_actual_dir)
++        list(APPEND Qt5Gui_${Name}_INCLUDE_DIRS ${_actual_dir})
+       endif()
++      unset(_actual_dir CACHE)
+     endforeach()
+-!!ENDIF
++
+     foreach(_lib ${Libs})
+         string(REGEX REPLACE "[^_A-Za-z0-9]" "_" _cmake_lib_name ${_lib})
+         if (NOT TARGET Qt5::Gui_${_cmake_lib_name} AND NOT _Qt5Gui_${_cmake_lib_name}_LIBRARY_DONE)
+@@ -158,11 +152,11 @@ endmacro()
+ 
+ 
+ !!IF !isEmpty(CMAKE_EGL_LIBS)
+-_qt5gui_find_extra_libs(EGL \"$$CMAKE_EGL_LIBS\" \"$$CMAKE_EGL_LIBDIR\" \"$$CMAKE_EGL_INCDIRS\")
++_qt5gui_find_extra_libs(EGL \"$$CMAKE_EGL_LIBS\" \"$$CMAKE_EGL_LIBDIR\" \"$$replace(CMAKE_EGL_INCDIRS,$$re_escape($$PKG_CONFIG_SYSROOT_DIR),)\")
+ !!ENDIF
+ 
+ !!IF !isEmpty(CMAKE_OPENGL_LIBS)
+-_qt5gui_find_extra_libs(OPENGL \"$$CMAKE_OPENGL_LIBS\" \"$$CMAKE_OPENGL_LIBDIR\" \"$$CMAKE_OPENGL_INCDIRS\")
++_qt5gui_find_extra_libs(OPENGL \"$$CMAKE_OPENGL_LIBS\" \"$$CMAKE_OPENGL_LIBDIR\" \"$$replace(CMAKE_OPENGL_INCDIRS,$$re_escape($$PKG_CONFIG_SYSROOT_DIR),)\")
+ 
+ !!ENDIF
+ 
+-- 
+2.13.6
+

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -31,6 +31,7 @@ SRC_URI += "\
     file://0013-Upgrade-double-conversion-to-v3.0.0.patch \
     file://0014-Check-glibc-version-for-renameat2-statx-on-non-boots.patch \
     file://0015-double-conversion-support-AARCH64EB-and-arm-BE.patch \
+    file://0001-Qt5GuiConfigExtras.cmake.in-cope-with-variable-path-.patch \
 "
 
 


### PR DESCRIPTION
If the qtbase recipe-sysroot no longer exists (e.g. because of rm_work)
a user of Qt5GuiConfigExtras.cmake will experience the following error:

| ERROR: Task (.../meta-qt5/recipes-qt/qt5/qtwebkit_git.bb:do_configure) failed with exit code '1'

| CMake Error in Source/WebCore/CMakeLists.txt:
|   Imported target "Qt5::Gui_EGL" includes non-existent path
|
|     ".../build/tmp-glibc/work/armv7at2hf-neon-imx-angstrom-linux-gnueabi/qtbase/5.11.2+gitAUTOINC+49efea26a5-r0/recipe-sysroot/usr/include/libdrm"

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>