### PR TITLE
python-pyqt5: Disable parallel install

### DIFF
--- a/recipes-python/pyqt5/python-pyqt5.inc
+++ b/recipes-python/pyqt5/python-pyqt5.inc
@@ -22,6 +22,8 @@ export HOST_SYS
 export STAGING_INCDIR
 export STAGING_LIBDIR
 
+PARALLEL_MAKEINST = ""
+
 DISABLED_FEATURES = "PyQt_Desktop_OpenGL PyQt_Accessibility PyQt_SessionManager"
 
 DISABLED_FEATURES_append_arm = " PyQt_qreal_double"


### PR DESCRIPTION
Avoid certain race during do_install

|   File
"/mnt/a/yoe/build/tmp/work/cortexa7t2hf-neon-vfpv4-yoe-linux-gnueabi/python-pyqt5/5.11.3-r0/PyQt5_gpl-5.11.3/mk_distinfo.py",
line 108, in <module>
|     fn_f = open(fn, 'rb')
| FileNotFoundError: [Errno 2] No such file or directory:
'/mnt/a/yoe/build/tmp/work/cortexa7t2hf-neon-vfpv4-yoe-linux-gnueabi/python-pyqt5/5.11.3-r0/image//usr/lib/python2.7/site-packages/PyQt5/QtCore.so'

Signed-off-by: Khem Raj <raj.khem@gmail.com>