### PR TITLE
packagegroup-qt5-toolchain-target: Skip qtwebkit if opengl not found

### DIFF
--- a/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bb
+++ b/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bb
@@ -9,7 +9,7 @@ PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"
 
 # Requires Ruby to work
 USE_RUBY = " \
-    qtwebkit-dev \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'qtwebkit-dev', '', d)} \
 "
 
 # Requires Wayland to work


### PR DESCRIPTION
Resolves #129

Signed-off-by: Scott Ellis <scott@jumpnowtek.com>