### PR TITLE
python-pyqt5: MAKEFLAGS pass -j 1 via MAKEFLAGS during do_install

### DIFF
--- a/recipes-python/pyqt5/python-pyqt5.inc
+++ b/recipes-python/pyqt5/python-pyqt5.inc
@@ -56,7 +56,7 @@ do_compile() {
 
 do_install() {
     cd ${S}
-    oe_runmake install
+    oe_runmake MAKEFLAGS='-j 1' install
 }
 
 FILES_${PN} += "${libdir}/${PYTHON_DIR}${PYTHON_ABI}/site-packages ${datadir}/sip/PyQt5/"


### PR DESCRIPTION
The fix to reset PARALLEL_MAKEINST doesn't work here because qmake
bbclass creates EXTRA_OEMAKE where it passes the -jX via MAKEFLAGS
its better to set MAKEFLAGS in do_install to undo that effect

Signed-off-by: Khem Raj <raj.khem@gmail.com>