### PR TITLE
qtwebengine: Configure Ninja to honor PARALLEL_MAKE

### DIFF
--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -92,6 +92,7 @@ require qt5-git.inc
 
 export GN_PKG_CONFIG_HOST = "${STAGING_BINDIR_NATIVE}/pkg-config-native"
 export GN_HOST_TOOLCHAIN_EXTRA_CPPFLAGS = "-I${STAGING_DIR_NATIVE}/usr/include"
+export NINJAFLAGS="${PARALLEL_MAKE}"
 
 do_configure() {
 


### PR DESCRIPTION
Fixes #137

Apparently, this was fairly easy :)
The `NINJAFLAGS` environment variable is picked up by `src/core/gn_run.pro`