### PR TITLE
libconnman-qt5: Don't harcode libdir to fix multilib build

### DIFF
--- a/recipes-connectivity/libconnman-qt/libconnman-qt5/0001-Fix-library-path-for-multilib-setups.patch
+++ b/recipes-connectivity/libconnman-qt/libconnman-qt5/0001-Fix-library-path-for-multilib-setups.patch
@@ -1,0 +1,25 @@
+Upstream-Status: pending
+
+From 9692239a31f0e47ea75b60388d5491d5155a888d Mon Sep 17 00:00:00 2001
+From: Andreas Oberritter <obi@saftware.de>
+Date: Mon, 17 Dec 2018 14:00:44 +0100
+Subject: [PATCH] Fix library path for multilib setups.
+
+Signed-off-by: Andreas Oberritter <obi@saftware.de>
+---
+ libconnman-qt/libconnman-qt.pro | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libconnman-qt/libconnman-qt.pro b/libconnman-qt/libconnman-qt.pro
+index 8cd58e8..bad8a5e 100644
+--- a/libconnman-qt/libconnman-qt.pro
++++ b/libconnman-qt/libconnman-qt.pro
+@@ -71,7 +71,7 @@ SOURCES += \
+     networksession.cpp \
+     counter.cpp
+ 
+-target.path = $$INSTALL_ROOT$$PREFIX/lib
++target.path = $$[QT_INSTALL_LIBS]
+ 
+ headers.files = $$PUBLIC_HEADERS
+ 

--- a/recipes-connectivity/libconnman-qt/libconnman-qt5_git.bb
+++ b/recipes-connectivity/libconnman-qt/libconnman-qt5_git.bb
@@ -10,6 +10,7 @@ PV = "1.2.7+git${SRCPV}"
 SRCREV = "ad7fef1c35a3e897913965f73b879a14d65043dd"
 SRC_URI = "git://git.merproject.org/mer-core/libconnman-qt.git;protocol=https \
     file://0001-Don-t-use-MeeGo-as-prefix-in-order-to-make-this-a-co.patch \
+    file://0001-Fix-library-path-for-multilib-setups.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Signed-off-by: Andreas Oberritter <obi@opendreambox.org>