### PR TITLE
qtwebkit: Disable JIT for mips64

### DIFF
--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -44,6 +44,7 @@ SRC_URI += "\
     file://0017-Define-QMAKE_CXX.COMPILER_MACROS-for-clang-on-linux.patch \
     file://0018-Fix-compile-issue-with-gcc-9.patch \
     file://0019-Fix-compilation-of-qendian-s-qswap-specializations-o.patch \
+    file://0022-Fix-qbswap-calls-for-Big-Endian-targets.patch \
 "
 
 # common for qtbase-native and nativesdk-qtbase

--- a/recipes-qt/qt5/qtbase-native_git.bb
+++ b/recipes-qt/qt5/qtbase-native_git.bb
@@ -39,6 +39,7 @@ SRC_URI += "\
     file://0017-Define-QMAKE_CXX.COMPILER_MACROS-for-clang-on-linux.patch \
     file://0018-Fix-compile-issue-with-gcc-9.patch \
     file://0019-Fix-compilation-of-qendian-s-qswap-specializations-o.patch \
+    file://0022-Fix-qbswap-calls-for-Big-Endian-targets.patch \
 "
 
 # common for qtbase-native and nativesdk-qtbase

--- a/recipes-qt/qt5/qtbase/0022-Fix-qbswap-calls-for-Big-Endian-targets.patch
+++ b/recipes-qt/qt5/qtbase/0022-Fix-qbswap-calls-for-Big-Endian-targets.patch
@@ -1,0 +1,26 @@
+From 63d4333946f086acea029ebd148ca46b1375fefc Mon Sep 17 00:00:00 2001
+From: Ville Voutilainen <ville.voutilainen@qt.io>
+Date: Fri, 4 Jan 2019 09:35:40 +0200
+Subject: [PATCH] Fix qbswap calls for Big Endian targets
+
+Upstream-Status: Backport
+Task-number: QTBUG-71945
+Change-Id: I5356f8e32d00ea591b1f65cdd4111276fcf876ac
+---
+ src/corelib/global/qendian.h | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+--- a/src/corelib/global/qendian.h
++++ b/src/corelib/global/qendian.h
+@@ -204,9 +204,9 @@ template <typename T> inline Q_DECL_CONS
+ template <typename T> inline Q_DECL_CONSTEXPR T qFromBigEndian(T source)
+ { return source; }
+ template <typename T> inline Q_DECL_CONSTEXPR T qToLittleEndian(T source)
+-{ return qbswap<T>(source); }
++{ return qbswap(source); }
+ template <typename T> inline Q_DECL_CONSTEXPR T qFromLittleEndian(T source)
+-{ return qbswap<T>(source); }
++{ return qbswap(source); }
+ template <typename T> inline void qToBigEndian(T src, void *dest)
+ { qToUnaligned<T>(src, dest); }
+ template <typename T> inline void qToLittleEndian(T src, void *dest)

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -35,6 +35,7 @@ SRC_URI += "\
     file://0017-Define-QMAKE_CXX.COMPILER_MACROS-for-clang-on-linux.patch \
     file://0018-Fix-compile-issue-with-gcc-9.patch \
     file://0019-Fix-compilation-of-qendian-s-qswap-specializations-o.patch \
+    file://0022-Fix-qbswap-calls-for-Big-Endian-targets.patch \
 "
 
 

--- a/recipes-qt/qt5/qtwebkit_git.bb
+++ b/recipes-qt/qt5/qtwebkit_git.bb
@@ -49,6 +49,10 @@ EXTRA_OECMAKE += " \
 
 EXTRA_OECMAKE_append_toolchain-clang = " -DCMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES:PATH='${STAGING_INCDIR}'"
 
+# JIT not supported on MIPS64
+EXTRA_OECMAKE_append_mips64 = " -DENABLE_JIT=OFF "
+EXTRA_OECMAKE_append_mips64el = " -DENABLE_JIT=OFF "
+
 PACKAGECONFIG ??= "qtlocation qtmultimedia qtsensors qtwebchannel \
     ${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)} \
     fontconfig \


### PR DESCRIPTION
It does not build with JIT

git/Source/JavaScriptCore/assembler/MacroAssembler.h:64:2: error: #error "The MacroAssembler is not supported on this platform."
   64 | #error "The MacroAssembler is not supported on this platform."
      |  ^~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>