### PR TITLE
gstreamer1.0-plugins-good: fix qt5 dependency

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -4,12 +4,4 @@ PACKAGECONFIG[qt5] = '--enable-qt \
                       --with-moc="${OE_QMAKE_PATH_EXTERNAL_HOST_BINS}/moc" \
                       --with-uic="${OE_QMAKE_PATH_EXTERNAL_HOST_BINS}/uic" \
                       --with-rcc="${OE_QMAKE_PATH_EXTERNAL_HOST_BINS}/rcc" \
-                     ,--disable-qt,qtbase qtdeclarative qtbase-native'
-
-# The GStreamer Qt5 plugin needs desktop OpenGL or OpenGL ES to work, so make sure it is enabled
-python() {
-    cur_packageconfig = d.getVar('PACKAGECONFIG',True).split()
-    if 'qt5' in cur_packageconfig and not (('opengl' in cur_packageconfig) or ('gles2' in cur_packageconfig)):
-        gl_packageconfig = d.getVar('PACKAGECONFIG_GL',True)
-        d.appendVar('PACKAGECONFIG', ' ' + gl_packageconfig)
-}
+                     ,--disable-qt,gstreamer1.0-plugins-base qtbase qtdeclarative qtbase-native'


### PR DESCRIPTION
Commit 73f99f2 ("gstreamer1.0-plugins-{good,bad}: move the qt5
PACKAGECONFIG from bad to good bbappend") just copied the bbappend file
without checking the dependencies.

The qt5 plugin needs the gl plugin which was moved in gstreamer 1.14
from bad to base. So the pyhton() function checking the PACKAGECONFIG_GL
isn't needed here, furthermore it causes bitbake errors:

     0013:        gl_packageconfig = d.getVar('PACKAGECONFIG_GL', expand=True)
     0014:        with open("/tmp/marcotest", "w") as f:
     0015:            print(gl_packageconfig, file=f)
     0016:        d.appendVar('PACKAGECONFIG', ' ' + gl_packageconfig)
      *** 0017:}
     Exception: TypeError: can only concatenate str (not "NoneType") to str

The patch removes the python() function to fix this and adds the
gstreamer1.0-plugins-base dependency to have access to the gl plugin.

Signed-off-by: Marco Felsch <m.felsch@pengutronix.de>