### PR TITLE
qtwayland: workaround upstream bug: install missing headers manually

### DIFF
--- a/recipes-qt/qt5/qtwayland_git.bb
+++ b/recipes-qt/qt5/qtwayland_git.bb
@@ -44,3 +44,20 @@ BBCLASSEXTEND =+ "native nativesdk"
 # The same issue as in qtbase:
 # http://errors.yoctoproject.org/Errors/Details/152641/
 LDFLAGS_append_x86 = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', ' -fuse-ld=bfd ', '', d)}"
+
+# Since version 5.11.2 some private headers are not installed. Work around
+# until fixed upstream. See https://bugreports.qt.io/browse/QTBUG-71340 for
+# further details
+do_install_append() {
+    if [ -d "${B}/src/client" ]; then
+        upstream_pv=`echo "${PV}" | sed 's:+git.*::g'`
+        for header in `find ${B}/src/client -name '*wayland-*.h'`; do
+            header_base=`basename $header`
+            dest="${D}${includedir}/QtWaylandClient/$upstream_pv/QtWaylandClient/private/$header_base"
+            if [ ! -e "$dest" ]; then
+                echo "Manual install: $header_base to $dest"
+                install -m 644 "$header" "$dest"
+            fi
+        done
+    fi
+}


### PR DESCRIPTION
* Have tried to keep this as less invasive as possible
* To be honest: Have tested this with thud only - reading QTBUG-71340 tells me the bug is still there