### PR TITLE
nativesdk-qtbase: use rpath for nativesdk Qt tools

### DIFF
--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -80,7 +80,6 @@ QT_CONFIG_FLAGS += " \
     -shared \
     -silent \
     -no-pch \
-    -no-rpath \
     -pkg-config \
     ${PACKAGECONFIG_CONFARGS} \
 "
@@ -142,7 +141,6 @@ do_configure() {
         -nomake examples \
         -nomake tests \
         -no-compile-examples \
-        -no-rpath \
         -platform ${OE_QMAKE_PLATFORM_NATIVE} \
         -xplatform ${OE_QMAKE_PLATFORM} \
         ${QT_CONFIG_FLAGS}


### PR DESCRIPTION
rpath is needed to be able to run qt tools from the sdk without
having the sdk's lib dir explicitly in LD_LIBRARY_PATH or relying
on host libraries. Qt uses relative rpaths, so the build directories
are not used there.

Signed-off-by: Samuli Piippo <samuli.piippo@qt.io>