### PR TITLE
qtbase: let user decide how to link openssl to Qt5 libraries

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -93,6 +93,9 @@ PACKAGECONFIG ?= " \
     ${PACKAGECONFIG_SYSTEM} \
     ${PACKAGECONFIG_DISTRO} \
 "
+# Choose whether to link to OpenSSL library at linking time or run time
+# Leave the variable empty to let the buildsystem decide, or specify -linked or -runtime
+OPENSSL_LINKING_MODE ??= ""
 
 PACKAGECONFIG[static] = "-static,-shared"
 PACKAGECONFIG[release] = "-release,-debug"
@@ -152,7 +155,7 @@ PACKAGECONFIG[kms] = "-kms,-no-kms,drm virtual/egl"
 PACKAGECONFIG[gbm] = "-gbm,-no-gbm,virtual/libgbm"
 PACKAGECONFIG[icu] = "-icu,-no-icu,icu"
 PACKAGECONFIG[udev] = "-libudev,-no-libudev,udev"
-PACKAGECONFIG[openssl] = "-openssl,-no-openssl,openssl,libssl"
+PACKAGECONFIG[openssl] = "-openssl${OPENSSL_LINKING_MODE},-no-openssl,openssl,libssl"
 PACKAGECONFIG[widgets] = "-widgets,-no-widgets"
 PACKAGECONFIG[libproxy] = "-libproxy,-no-libproxy,libproxy"
 PACKAGECONFIG[libinput] = "-libinput,-no-libinput,libinput"


### PR DESCRIPTION
Switch from the configure script was extended from -openssl to -openssl-{linked,runtime} so that one can select whether to enable ssl library at linking time or runtime (with dlopen()), or letting the build system decide if no flag is specified.

Now with the OPENSSL_LINKING_MODE variable, it is possible to decide which linking mode to be used.

Signed-off-by: Francesco Giancane <francesco.giancane@polito.it>