### PR TITLE
qtbase: fix target mkspec adjustment

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -270,6 +270,9 @@ sed -i \
     -e 's:HostSpec =.*:HostSpec = ${TARGET_MKSPEC}:g' \
     -e 's:TargetSpec =.*:TargetSpec = ${TARGET_MKSPEC}:g' \
     $D${bindir}/qt.conf
+}
+
+pkg_postinst_${PN}-mkspecs () {
 sed -i 's: cross_compile : :g' $D${OE_QMAKE_PATH_ARCHDATA}/mkspecs/qconfig.pri
 sed -i \
     -e 's: cross_compile : :g' \


### PR DESCRIPTION
mkspecs are not part of qtbase-tools

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>