### PR TITLE
qtbase, packagegroup-qt5-toolchain-target: widgets are needed by qtharts

### DIFF
--- a/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bb
+++ b/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bb
@@ -26,6 +26,13 @@ USE_X11 = " \
     qtx11extras-mkspecs \
 "
 
+# Requires Widgets to work
+USE_WIDGETS = " \
+    qtcharts-dev \
+    qtcharts-mkspecs \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'qtcharts-qmlplugins', '', d)} \
+"
+
 RDEPENDS_${PN} += " \
     packagegroup-core-standalone-sdk-target \
     libsqlite3-dev \
@@ -39,9 +46,7 @@ RDEPENDS_${PN} += " \
     qtbase-tools \
     qttranslations-qtbase \
     qttranslations-qthelp \
-    qtcharts-dev \
-    qtcharts-mkspecs \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'qtcharts-qmlplugins', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'widgets', '${USE_WIDGETS}', '', d)} \
     qtconnectivity-dev \
     qtconnectivity-mkspecs \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'qtconnectivity-qmlplugins', '', d)} \

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -72,9 +72,10 @@ PACKAGECONFIG_DISTRO ?= ""
 PACKAGECONFIG_RELEASE ?= "release"
 # This is in qt5.inc, because qtwebkit-examples are using it to enable ca-certificates dependency
 # PACKAGECONFIG_OPENSSL ?= "openssl"
-PACKAGECONFIG_DEFAULT ?= "dbus udev evdev widgets tools libs freetype tests \
+PACKAGECONFIG_DEFAULT ?= "dbus udev evdev tools libs freetype tests \
     ${@bb.utils.contains('SELECTED_OPTIMIZATION', '-Os', 'optimize-size ltcg', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'qt5-static', 'static', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'widgets', 'widgets', '', d)} \
 "
 
 PACKAGECONFIG ?= " \


### PR DESCRIPTION
qtcharts depends on widgets in PACKAGECONFIG of qtbase.
Right now this dependency is not checked in RDEPENDS of
packagegroup-qt5-toolchain-target.

If widgets are removed from PACKAGECONFIG of qtbase the error occurs,
that nothing provides qtcharts-dev / qtcharts-mkspecs / qtcharts-qmlplugins.

With this patch qtcharts-* will only be in RDEPENDS, if widgets are set in
PACKAGECONFIG of qtbase. Therefore widgets need to be added in DISTRO_FEATURES.


This patch could solve issue: https://github.com/meta-qt5/meta-qt5/issues/185