### PR TITLE
qtbase: Check for devices.py before operating on it

### DIFF
--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -157,8 +157,10 @@ do_install() {
     install -m 644 ${WORKDIR}/OEQt5Toolchain.cmake ${D}${datadir}/cmake/OEToolchainConfig.cmake.d/
 
     # Fix up absolute paths in scripts
-    sed -i -e '1s,#!/usr/bin/python,#! ${USRBINPATH}/env python,' \
-        ${D}${OE_QMAKE_PATH_QT_ARCHDATA}/mkspecs/features/uikit/devices.py
+    if [ -e ${D}${OE_QMAKE_PATH_QT_ARCHDATA}/mkspecs/features/uikit/devices.py ]; then
+        sed -i -e '1s,#!/usr/bin/python,#! ${USRBINPATH}/env python,' \
+            ${D}${OE_QMAKE_PATH_QT_ARCHDATA}/mkspecs/features/uikit/devices.py
+    fi
 }
 
 fakeroot do_generate_qt_environment_file() {

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -257,8 +257,10 @@ do_install_append() {
     generate_target_qt_config_file ${D}${OE_QMAKE_PATH_BINS}/qt.conf
 
     # Fix up absolute paths in scripts
-    sed -i -e '1s,#!/usr/bin/python,#! ${USRBINPATH}/env python,' \
-        ${D}${OE_QMAKE_PATH_QT_ARCHDATA}/mkspecs/features/uikit/devices.py
+    if [ -e ${D}${OE_QMAKE_PATH_QT_ARCHDATA}/mkspecs/features/uikit/devices.py ]; then
+        sed -i -e '1s,#!/usr/bin/python,#! ${USRBINPATH}/env python,' \
+            ${D}${OE_QMAKE_PATH_QT_ARCHDATA}/mkspecs/features/uikit/devices.py
+    fi
 }
 
 # mkspecs have mac specific scripts that depend on perl and bash


### PR DESCRIPTION
Fixes

sed: can't read /mnt/a/yoe/build/tmp/work/cortexa7t2hf-neon-vfpv4-yoe-linux-gnueabi/qtbase/5.12.2+gitAUTOINC+856fb1ab44-r0/image/usr/lib/mkspecs/features/uikit/devices.py: No such file or directory

Signed-off-by: Khem Raj <raj.khem@gmail.com>