### PR TITLE
qtwayland: improve manual header installation

### DIFF
--- a/recipes-qt/qt5/qtwayland_git.bb
+++ b/recipes-qt/qt5/qtwayland_git.bb
@@ -48,12 +48,24 @@ LDFLAGS_append_x86 = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', ' -f
 # Since version 5.11.2 some private headers are not installed. Work around
 # until fixed upstream. See https://bugreports.qt.io/browse/QTBUG-71340 for
 # further details
+QTWAYLAND_INSTALL_PRIVATE_HEADERS_MANUALLY ?= "1"
+# First 6 characters before first + (e.g. 5.11.3-+git) or - (e.g. 5.11.3-2)
+SHRT_VER ?= "${@d.getVar('PV').split('+')[0].split('-')[0]}"
 do_install_append() {
-    if [ -d "${B}/src/client" ]; then
-        upstream_pv=`echo "${PV}" | sed 's:+git.*::g'`
+    if [ -d "${B}/src/client" -a "${QTWAYLAND_INSTALL_PRIVATE_HEADERS_MANUALLY}" = "1" ]; then
         for header in `find ${B}/src/client -name '*wayland-*.h'`; do
             header_base=`basename $header`
-            dest="${D}${includedir}/QtWaylandClient/$upstream_pv/QtWaylandClient/private/$header_base"
+            dest="${D}${includedir}/QtWaylandClient/${SHRT_VER}/QtWaylandClient/private/$header_base"
+            if [ ! -e "$dest" ]; then
+                echo "Manual install: $header_base to $dest"
+                install -m 644 "$header" "$dest"
+            fi
+        done
+    fi
+    if [ -d "${B}/src/compositor" -a "${QTWAYLAND_INSTALL_PRIVATE_HEADERS_MANUALLY}" = "1" ]; then
+        for header in `find ${B}/src/compositor -name '*wayland-*.h'`; do
+            header_base=`basename $header`
+            dest="${D}${includedir}/QtCompositor/${SHRT_VER}/QtCompositor/private/$header_base"
             if [ ! -e "$dest" ]; then
                 echo "Manual install: $header_base to $dest"
                 install -m 644 "$header" "$dest"


### PR DESCRIPTION
* allow to disable this completely with
  QTWAYLAND_INSTALL_PRIVATE_HEADERS_MANUALLY
  e.g. in case you already have your own bbappend resolving this
  differently
* use SHRT_VER variable and allow to change it in .bbappend
  e.g. in webOS we have different version with different format
  without "+git" and 5.11.3-2 ended in upstream_pv which caused
  do_install to fail because
  ${D}${includedir}/QtWaylandClient/5.11.3-2
  doesn't exist, split the PV by + as well - to cover both schemes
  and allow users to set SHRT_VER to something else if they have
  even weirder PV
* install the QtCompositor headers in the same way as QtWaylandClient
  we have custom compositor and with 5.11 it was failing to build
  because of missing headers, so I had this in .bbappend already
  (I thought it was only our issue, because we were using 5.4 based
  QtWayland with 5.11, but the same happends with 5.6 based one and
  probably newer as well (I don't know what qtwayland version Andreas
  was using when first sending the previous qtwayland patch).
* with 5.4 QtWayland and 5.11, I've updated sync.profile with
  %inject_headers and @private_headers
  built even with this sync.profile change the syncqt.pl in do_install
  doesn't install these 5.4 specific profile headers and qtwayland-webos
  and luna-surfacemanager fail to build.

  This is the diff between:
  recipe-sysroot-native/usr/bin/syncqt.pl -version 4.5.2 -showonly
  with Qt 5.6 and 5.11

  @@ -1,6 +1,5 @@
  -<srcbase> = BUILD/work/qemux86-webos-linux/qtwayland/5.4.2-119-r0/git
  -<bldbase> = BUILD/work/qemux86-webos-linux/qtwayland/5.4.2-119-r0/git
  -<outbase> = BUILD/work/qemux86-webos-linux/qtwayland/5.4.2-119-r0/git
  +<srcbase> = BUILD/work/qemux86-webos-linux/qtwayland/5.4.2-119-r0/git
  +<outbase> = BUILD/work/qemux86-webos-linux/qtwayland/5.4.2-119-r0/git
   pmtrace_qtwaylandclient_provider.h [QtWaylandClient]
   qtwaylandclienttracer.h [QtWaylandClient]
   qwaylandabstractdecoration_p.h [QtWaylandClient]
  @@ -34,34 +33,6 @@
   qwaylandwlshellsurface_p.h [QtWaylandClient]
   qwaylandxdgshell_p.h [QtWaylandClient]
   qwaylandxdgsurface_p.h [QtWaylandClient]
  -qwayland-hardware-integration.h [QtWaylandClient]
  -qwayland-output-extension.h [QtWaylandClient]
  -qwayland-qt-windowmanager.h [QtWaylandClient]
  -qwayland-qtkey-extension.h [QtWaylandClient]
  -qwayland-server-buffer-extension.h [QtWaylandClient]
  -qwayland-sub-surface-extension.h [QtWaylandClient]
  -qwayland-surface-extension.h [QtWaylandClient]
  -qwayland-text.h [QtWaylandClient]
  -qwayland-text-input-unstable-v2.h [QtWaylandClient]
  -qwayland-touch-extension.h [QtWaylandClient]
  -qwayland-wayland.h [QtWaylandClient]
  -qwayland-windowmanager.h [QtWaylandClient]
  -qwayland-xdg-shell-unstable-v6.h [QtWaylandClient]
  -qwayland-xdg-shell.h [QtWaylandClient]
  -wayland-hardware-integration-client-protocol.h [QtWaylandClient]
  -wayland-output-extension-client-protocol.h [QtWaylandClient]
  -wayland-qt-windowmanager-client-protocol.h [QtWaylandClient]
  -wayland-qtkey-extension-client-protocol.h [QtWaylandClient]
  -wayland-server-buffer-extension-client-protocol.h [QtWaylandClient]
  -wayland-sub-surface-extension-client-protocol.h [QtWaylandClient]
  -wayland-surface-extension-client-protocol.h [QtWaylandClient]
  -wayland-text-client-protocol.h [QtWaylandClient]
  -wayland-text-input-unstable-v2-client-protocol.h [QtWaylandClient]
  -wayland-touch-extension-client-protocol.h [QtWaylandClient]
  -wayland-wayland-client-protocol.h [QtWaylandClient]
  -wayland-windowmanager-client-protocol.h [QtWaylandClient]
  -wayland-xdg-shell-client-protocol.h [QtWaylandClient]
  -wayland-xdg-shell-unstable-v6-client-protocol.h [QtWaylandClient]
   qwaylandclientbufferintegration_p.h [QtWaylandClient]
   qwaylandclientbufferintegrationfactory_p.h [QtWaylandClient]
   qwaylandclientbufferintegrationplugin_p.h [QtWaylandClient]
  @@ -84,38 +55,6 @@
   SYMBOL: QWaylandEglWindow
   qwaylandglcontext.h [QtWaylandClient]
   SYMBOL: QWaylandGLContext
  -qwayland-server-wayland.h [QtCompositor]
  -qwayland-server-hardware-integration.h [QtCompositor]
  -qwayland-server-input-method.h [QtCompositor]
  -qwayland-server-ivi-application.h [QtCompositor]
  -qwayland-server-output-extension.h [QtCompositor]
  -qwayland-server-qt-windowmanager.h [QtCompositor]
  -qwayland-server-qtkey-extension.h [QtCompositor]
  -qwayland-server-server-buffer-extension.h [QtCompositor]
  -qwayland-server-sub-surface-extension.h [QtCompositor]
  -qwayland-server-surface-extension.h [QtCompositor]
  -qwayland-server-text.h [QtCompositor]
  -qwayland-server-text-input-unstable-v2.h [QtCompositor]
  -qwayland-server-touch-extension.h [QtCompositor]
  -qwayland-server-windowmanager.h [QtCompositor]
  -qwayland-server-xdg-shell-unstable-v6.h [QtCompositor]
  -qwayland-server-xdg-shell.h [QtCompositor]
  -wayland-hardware-integration-server-protocol.h [QtCompositor]
  -wayland-input-method-server-protocol.h [QtCompositor]
  -wayland-ivi-application-server-protocol.h [QtCompositor]
  -wayland-output-extension-server-protocol.h [QtCompositor]
  -wayland-qt-windowmanager-server-protocol.h [QtCompositor]
  -wayland-qtkey-extension-server-protocol.h [QtCompositor]
  -wayland-server-buffer-extension-server-protocol.h [QtCompositor]
  -wayland-sub-surface-extension-server-protocol.h [QtCompositor]
  -wayland-surface-extension-server-protocol.h [QtCompositor]
  -wayland-text-input-unstable-v2-server-protocol.h [QtCompositor]
  -wayland-text-server-protocol.h [QtCompositor]
  -wayland-touch-extension-server-protocol.h [QtCompositor]
  -wayland-wayland-server-protocol.h [QtCompositor]
  -wayland-windowmanager-server-protocol.h [QtCompositor]
  -wayland-xdg-shell-server-protocol.h [QtCompositor]
  -wayland-xdg-shell-unstable-v6-server-protocol.h [QtCompositor]
   pmtrace_qtwayland_provider.h [QtCompositor]
   qtwaylandtracer.h [QtCompositor]
   qwaylandbufferref.h [QtCompositor]

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>