### PR TITLE
qtwayland: improve manual header installation

### DIFF
--- a/recipes-qt/qt5/qtwayland_git.bb
+++ b/recipes-qt/qt5/qtwayland_git.bb
@@ -48,12 +48,24 @@ LDFLAGS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', ' -fuse-
 # Since version 5.11.2 some private headers are not installed. Work around
 # until fixed upstream. See https://bugreports.qt.io/browse/QTBUG-71340 for
 # further details
+QTWAYLAND_INSTALL_PRIVATE_HEADERS_MANUALLY ?= "1"
+# First 6 characters before first + (e.g. 5.11.3-+git) or - (e.g. 5.11.3-2)
+SHRT_VER ?= "${@d.getVar('PV').split('+')[0].split('-')[0]}"
 do_install_append() {
-    if [ -d "${B}/src/client" ]; then
-        upstream_pv=`echo "${PV}" | sed 's:+git.*::g'`
+    if [ -d "${B}/src/client" -a "${QTWAYLAND_INSTALL_PRIVATE_HEADERS_MANUALLY}" = "1" ]; then
         for header in `find ${B}/src/client -name '*wayland-*.h'`; do
             header_base=`basename $header`
-            dest="${D}${includedir}/QtWaylandClient/$upstream_pv/QtWaylandClient/private/$header_base"
+            dest="${D}${includedir}/QtWaylandClient/${SHRT_VER}/QtWaylandClient/private/$header_base"
+            if [ ! -e "$dest" ]; then
+                echo "Manual install: $header_base to $dest"
+                install -m 644 "$header" "$dest"
+            fi
+        done
+    fi
+    if [ -d "${B}/src/compositor" -a "${QTWAYLAND_INSTALL_PRIVATE_HEADERS_MANUALLY}" = "1" ]; then
+        for header in `find ${B}/src/compositor -name '*wayland-*.h'`; do
+            header_base=`basename $header`
+            dest="${D}${includedir}/QtCompositor/${SHRT_VER}/QtCompositor/private/$header_base"
             if [ ! -e "$dest" ]; then
                 echo "Manual install: $header_base to $dest"
                 install -m 644 "$header" "$dest"

--- a/recipes-qt/qt5/qtwayland_git.bb
+++ b/recipes-qt/qt5/qtwayland_git.bb
@@ -44,3 +44,20 @@ BBCLASSEXTEND =+ "native nativesdk"
 # The same issue as in qtbase:
 # http://errors.yoctoproject.org/Errors/Details/152641/
 LDFLAGS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', ' -fuse-ld=bfd ', '', d)}"
+
+# Since version 5.11.2 some private headers are not installed. Work around
+# until fixed upstream. See https://bugreports.qt.io/browse/QTBUG-71340 for
+# further details
+do_install_append() {
+    if [ -d "${B}/src/client" ]; then
+        upstream_pv=`echo "${PV}" | sed 's:+git.*::g'`
+        for header in `find ${B}/src/client -name '*wayland-*.h'`; do
+            header_base=`basename $header`
+            dest="${D}${includedir}/QtWaylandClient/$upstream_pv/QtWaylandClient/private/$header_base"
+            if [ ! -e "$dest" ]; then
+                echo "Manual install: $header_base to $dest"
+                install -m 644 "$header" "$dest"
+            fi
+        done
+    fi
+}


### PR DESCRIPTION
The issue from 5.11 still exists in 5.12.

These header files were missing for me:

diff -rq 5.6.3-129-r0-do-install-*/image
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: qwayland-server-hardware-integration.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: qwayland-server-input-method.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: qwayland-server-qtkey-extension.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: qwayland-server-server-buffer-extension.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: qwayland-server-sub-surface-extension.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: qwayland-server-surface-extension.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: qwayland-server-text.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: qwayland-server-touch-extension.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: qwayland-server-wayland.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: qwayland-server-windowmanager.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: wayland-hardware-integration-server-protocol.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: wayland-input-method-server-protocol.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: wayland-qtkey-extension-server-protocol.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: wayland-server-buffer-extension-server-protocol.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: wayland-sub-surface-extension-server-protocol.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: wayland-surface-extension-server-protocol.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: wayland-text-server-protocol.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: wayland-touch-extension-server-protocol.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: wayland-wayland-server-protocol.h
Only in 5.6.3-129-r0-do-install-meta-qt5/image/usr/include/QtCompositor/5.6.3/QtCompositor/private: wayland-windowmanager-server-protocol.h
