### PR TITLE
qt5: partial fix for v5.12.3 tags

### DIFF
--- a/recipes-qt/qt5/qt3d_git.bb
+++ b/recipes-qt/qt5/qt3d_git.bb
@@ -36,9 +36,6 @@ do_configure_prepend() {
          ${S}/src/quick3d/imports/input/importsinput.pro
 }
 
-# Use e84d8d2a81eb81f9b1ea9f40d4da36d09a97b246 instead of
-# 7da5c4c35a657ea43663b4ed0d65e896b8db5c69 because the v5.12.3 tag wasn't
-# merged to 5.12 branch yet
-SRCREV = "e84d8d2a81eb81f9b1ea9f40d4da36d09a97b246"
+SRCREV = "7da5c4c35a657ea43663b4ed0d65e896b8db5c69"
 
 BBCLASSEXTEND += "native nativesdk"

--- a/recipes-qt/qt5/qtknx_git.bb
+++ b/recipes-qt/qt5/qtknx_git.bb
@@ -9,5 +9,4 @@ LIC_FILES_CHKSUM = " \
 
 DEPENDS += "qtbase"
 
-# v5.12.3 tag wasn't created yet
-SRCREV = "ae6c0fe18fff0bedced9800b11940f396b66596d"
+SRCREV = "0dfc76b080df56ef1638bd6a9deb7325692bc242"

--- a/recipes-qt/qt5/qtmqtt_git.bb
+++ b/recipes-qt/qt5/qtmqtt_git.bb
@@ -9,5 +9,4 @@ LIC_FILES_CHKSUM = " \
 
 DEPENDS += "qtbase"
 
-# v5.12.3 tag wasn't created yet
-SRCREV = "acff2f2611e271b83c9190b060d42c88bb292fa5"
+SRCREV = "6281dd7e375f94a5e7f78055c0bebba93a2b0e02"

--- a/recipes-qt/qt5/qtopcua_git.bb
+++ b/recipes-qt/qt5/qtopcua_git.bb
@@ -15,5 +15,4 @@ SECURITY_STRINGFORMAT = ""
 
 DEPENDS += "qtbase qtdeclarative"
 
-# v5.12.3 tag wasn't created yet
-SRCREV = "e42d517e350c18d6e6c5c3081e3005f10a5c20ab"
+SRCREV = "56d2b5df55c9a6ea7d21f3412193903f2504249e"

--- a/recipes-qt/qt5/qtremoteobjects_git.bb
+++ b/recipes-qt/qt5/qtremoteobjects_git.bb
@@ -24,9 +24,6 @@ PACKAGECONFIG[tools-only] = "CONFIG+=tools-only"
 
 EXTRA_QMAKEVARS_PRE += "${PACKAGECONFIG_CONFARGS}"
 
-# Use 119b222dd5ee8f4410f87c5854e6e9ee65436309 instead of
-# db1e447c46062946e57d7de9c0e0ea5fddc997f6 because the v5.12.3 tag wasn't
-# merged to 5.12 branch yet
-SRCREV = "119b222dd5ee8f4410f87c5854e6e9ee65436309"
+SRCREV = "db1e447c46062946e57d7de9c0e0ea5fddc997f6"
 
 BBCLASSEXTEND += "native nativesdk"

--- a/recipes-qt/qt5/qttools_git.bb
+++ b/recipes-qt/qt5/qttools_git.bb
@@ -32,10 +32,7 @@ EXTRA_QMAKEVARS_PRE += " \
     ${@bb.utils.contains('PACKAGECONFIG', 'qtwebkit', '', 'CONFIG+=noqtwebkit', d)} \
 "
 
-# Use 50335cb26bb88930f5e2a204642439cc9a4d2282 instead of
-# 1f8d498752fed0b2b92d6a619aa11524dd771998 because the v5.12.3 tag wasn't
-# merged to 5.12 branch yet
-SRCREV = "50335cb26bb88930f5e2a204642439cc9a4d2282"
+SRCREV = "1f8d498752fed0b2b92d6a619aa11524dd771998"
 
 BBCLASSEXTEND = "native nativesdk"
 


### PR DESCRIPTION
* v5.12.3 tags in qtknx, qtmqtt, qtopcua, qttools, qtremoteobjects are fine now, but qt3d still isn't in 5.12 branch

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>