### PR TITLE
qtwebengine: restore the fix for build with clang/libc++ on aarch64/arm

### DIFF
--- a/recipes-qt/qt5/qtwebengine/0001-Force-host-toolchain-configuration.patch
+++ b/recipes-qt/qt5/qtwebengine/0001-Force-host-toolchain-configuration.patch
@@ -1,4 +1,4 @@
-From bf92c8a03189d7a559aff7d62c2d9fc6047d2659 Mon Sep 17 00:00:00 2001
+From eb0b90b8809a8d8bd76999056d74d433a6c23184 Mon Sep 17 00:00:00 2001
 From: Samuli Piippo <samuli.piippo@qt.io>
 Date: Wed, 15 Mar 2017 13:53:28 +0200
 Subject: [PATCH] Force host toolchain configuration
@@ -18,7 +18,7 @@ Signed-off-by: Samuli Piippo <samuli.piippo@qt.io>
  2 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/src/buildtools/configure_host.pro b/src/buildtools/configure_host.pro
-index dd0d3e32..70161c82 100644
+index dd0d3e32..6312c867 100644
 --- a/src/buildtools/configure_host.pro
 +++ b/src/buildtools/configure_host.pro
 @@ -4,7 +4,7 @@ TEMPLATE = aux
@@ -37,9 +37,9 @@ index dd0d3e32..70161c82 100644
 -"  cc = \"$$which($$QMAKE_CC)\" " \
 -"  cxx = \"$$which($$QMAKE_CXX)\" " \
 -"  ld = \"$$which($$QMAKE_LINK)\" " \
-+"  cc = \"$$which(gcc)\" " \
-+"  cxx = \"$$which(g++)\" " \
-+"  ld = \"$$which(g++)\" " \
++"  cc = \"$$which($$CC_host)\" " \
++"  cxx = \"$$which($$CXX_host)\" " \
++"  ld = \"$$which($$CXX_host)\" " \
  "  ar = \"$$which(ar)\" " \
  "  nm = \"$$which(nm)\" " \
  "  extra_cppflags = \"$$GN_HOST_EXTRA_CPPFLAGS\" " \
@@ -50,9 +50,9 @@ index dd0d3e32..70161c82 100644
 -"  cc = \"$$which($$QMAKE_CC)\" " \
 -"  cxx = \"$$which($$QMAKE_CXX)\" " \
 -"  ld = \"$$which($$QMAKE_LINK)\" " \
-+"  cc = \"$$which(gcc)\" " \
-+"  cxx = \"$$which(g++)\" " \
-+"  ld = \"$$which(g++)\" " \
++"  cc = \"$$which($$CC_host)\" " \
++"  cxx = \"$$which($$CXX_host)\" " \
++"  ld = \"$$which($$CXX_host)\" " \
  "  ar = \"$$which(ar)\" " \
  "  nm = \"$$which(nm)\" " \
  "  toolchain_args = { " \

--- a/recipes-qt/qt5/qtwebengine/0002-musl-don-t-use-pvalloc-as-it-s-not-available-on-musl.patch
+++ b/recipes-qt/qt5/qtwebengine/0002-musl-don-t-use-pvalloc-as-it-s-not-available-on-musl.patch
@@ -1,4 +1,4 @@
-From 9409b83e634b53eb59cc0935424ea6fca1f50491 Mon Sep 17 00:00:00 2001
+From b3125c1b3f32915aa80acf58a9d1eeab4e260b17 Mon Sep 17 00:00:00 2001
 From: Samuli Piippo <samuli.piippo@qt.io>
 Date: Tue, 12 Dec 2017 16:06:14 +0200
 Subject: [PATCH] musl: don't use pvalloc as it's not available on musl

--- a/recipes-qt/qt5/qtwebengine/0003-musl-link-against-libexecinfo.patch
+++ b/recipes-qt/qt5/qtwebengine/0003-musl-link-against-libexecinfo.patch
@@ -1,4 +1,4 @@
-From a24cb0ef3b7311719ec248f4f1771f192c7cf4a0 Mon Sep 17 00:00:00 2001
+From 983ba7f8f80165ade5347544f1e975bd6b67549e Mon Sep 17 00:00:00 2001
 From: Samuli Piippo <samuli.piippo@qt.io>
 Date: Thu, 14 Dec 2017 11:28:10 +0200
 Subject: [PATCH] musl: link against libexecinfo

--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -135,7 +135,7 @@ RDEPENDS_${PN}-examples += " \
 QT_MODULE_BRANCH_CHROMIUM = "69-based"
 
 # Patches from https://github.com/meta-qt5/qtwebengine/commits/b5.12
-# 5.12.meta-qt5.3
+# 5.12.meta-qt5.4
 SRC_URI += " \
     ${QT_GIT}/qtwebengine-chromium.git;name=chromium;branch=${QT_MODULE_BRANCH_CHROMIUM};protocol=${QT_GIT_PROTOCOL};destsuffix=git/src/3rdparty \
     file://0001-Force-host-toolchain-configuration.patch \


### PR DESCRIPTION
* it was fixed in:
  https://github.com/meta-qt5/meta-qt5/commit/5be2654885b3699520c4370579c929e2ce352e80
* but then when upgrading to 5.12.3 from meta-qt5/qtwebengine I've accidentally overwritten
  this one with the older version in:
  https://github.com/meta-qt5/meta-qt5/commit/e2707a016c3475c167a421c9c73d88f81cc61bd1

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>