### PR TITLE
qtbase-tools: Fix error during pkg_postinst

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -282,7 +282,7 @@ pkg_postinst_${PN}-tools () {
 sed -i \
     -e 's:HostSpec =.*:HostSpec = ${TARGET_MKSPEC}:g' \
     -e 's:TargetSpec =.*:TargetSpec = ${TARGET_MKSPEC}:g' \
-    $D${bindir}/qt.conf
+    $D${OE_QMAKE_PATH_BINS}/qt.conf
 }
 
 pkg_postinst_${PN}-mkspecs () {


### PR DESCRIPTION
When staging the sdk, the following error is seen:
sed: can't read <path-to-work>/sdk/image/usr/local/oecore-x86_64/sysroots/aarch64-oe-linux/usr/bin/qt.conf: No such file or directory
because the qt.conf file moved from /usr/bin/qt.conf to
/usr/bin/qt5/qt.conf

This change locates the qt.conf file during pkg_postinst using the
OE_QMAKE_PATH_BINS variable, just as when the file is created.

Fixes #197 