### PR TITLE
qtwebengine: arm: use OE specified -mcpu option

### DIFF
--- a/recipes-qt/qt5/qtwebengine/chromium/0022-chromium-Do-not-try-to-set-the-guessed-values-for-ma.patch
+++ b/recipes-qt/qt5/qtwebengine/chromium/0022-chromium-Do-not-try-to-set-the-guessed-values-for-ma.patch
@@ -1,0 +1,41 @@
+From 058158c568698f79c905c19e5ef32ca714f8223e Mon Sep 17 00:00:00 2001
+From: Johannes Pointner <johannes.pointner@br-automation.com>
+Date: Fri, 3 May 2019 09:12:38 +0200
+Subject: [PATCH 1/1] chromium: Do not try to set the guessed values for
+ march/mtune/float-abi OE config machinary has computed these values already
+ and fed it via compiler cmdline to chromium build
+
+I think upstream should check for the values on compiler cmdline
+before overriding these
+
+Upstream-Status: Inappropriate [OE-Specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Johannes Pointner <johannes.pointner@br-automation.com>
+---
+ chromium/build/config/compiler/BUILD.gn | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/chromium/build/config/compiler/BUILD.gn b/chromium/build/config/compiler/BUILD.gn
+index 1c42c49ea4..e919e157d7 100644
+--- a/chromium/build/config/compiler/BUILD.gn
++++ b/chromium/build/config/compiler/BUILD.gn
+@@ -742,15 +742,6 @@ config("compiler_cpu_abi") {
+     } else if (current_cpu == "arm") {
+       if (is_clang && !is_android && !is_nacl) {
+       }
+-      if (!is_nacl) {
+-        cflags += [
+-          "-march=$arm_arch",
+-          "-mfloat-abi=$arm_float_abi",
+-        ]
+-      }
+-      if (arm_tune != "") {
+-        cflags += [ "-mtune=$arm_tune" ]
+-      }
+     } else if (current_cpu == "arm64") {
+       if (is_clang && !is_android && !is_nacl && !is_fuchsia) {
+       }
+-- 
+2.21.0
+

--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -155,6 +155,7 @@ SRC_URI += " \
     file://chromium/0019-chromium-fix-build-with-clang.patch;patchdir=src/3rdparty \
     file://chromium/0020-chromium-Check-for-__ARM_FP-2-before-using-__fp16.patch;patchdir=src/3rdparty \
     file://chromium/0021-chromium-Exclude-CRC32-for-32bit-arm.patch;patchdir=src/3rdparty \
+    file://chromium/0022-chromium-Do-not-try-to-set-the-guessed-values-for-ma.patch;patchdir=src/3rdparty \
 "
 
 SRC_URI_append_libc-musl = "\


### PR DESCRIPTION
OE-Core sets -mcpu option, which is equivalent to -march and -mtune
combination. Therefore don't set -march and -mtune in chromium.

Fixes #198 