### PR TITLE
qmake5_base.bbclass: Don't expand find -name search patterns

### DIFF
--- a/classes/qmake5_base.bbclass
+++ b/classes/qmake5_base.bbclass
@@ -241,17 +241,17 @@ qmake5_base_do_install() {
     qmake5_base_fix_install ${STAGING_DIR_NATIVE}
 
     # Replace host paths with qmake built-in properties
-    find ${D} \( -name *.pri -or -name *.prl \) -exec \
+    find ${D} \( -name "*.pri" -or -name "*.prl" \) -exec \
         sed -i -e 's|${STAGING_DIR_NATIVE}|$$[QT_HOST_PREFIX/get]|g' \
             -e 's|${STAGING_DIR_HOST}|$$[QT_SYSROOT]|g' {} \;
 
     # Replace host paths with pkg-config built-in variable
-    find ${D} -name *.pc -exec \
+    find ${D} -name "*.pc" -exec \
         sed -i -e 's|prefix=${STAGING_DIR_HOST}|prefix=|g' \
             -e 's|${STAGING_DIR_HOST}|${pc_sysrootdir}|g' {} \;
 
     # Replace resolved lib path with the lib name
-    find ${D} -name *.cmake -exec \
+    find ${D} -name "*.cmake" -exec \
         sed -i -e 's@/[^;]*/lib\([^;]*\)\.\(so\|a\)@\1@g' {} \;
 
 }


### PR DESCRIPTION
A wildcard not put between quotes is expanded by bash. If files matching
the pattern are found in the source directory then the find command is
non-sense and fails.

This commit put those search patterns in quotes and fixes the
installation of some recipes.

Signed-off-by: Florent Revest <revestflo@gmail.com>

-----------

More info in https://superuser.com/questions/247057/difference-between-find-name-with-and-w-o-quotes