### PR TITLE
Use OE_QMAKE_PATH_EXTERNAL_HOST_BINS to allow cmake to find the rep compiler

### DIFF
--- a/recipes-qt/qt5/qtremoteobjects/0001-Use-OE_QMAKE_PATH_EXTERNAL_HOST_BINS-to-allow-cmake-.patch
+++ b/recipes-qt/qt5/qtremoteobjects/0001-Use-OE_QMAKE_PATH_EXTERNAL_HOST_BINS-to-allow-cmake-.patch
@@ -1,0 +1,23 @@
+From a8a434b22d93be4a8f6c6f6759b9e3c2cfa7590c Mon Sep 17 00:00:00 2001
+From: ibinderwolf <daniel@bluepattern.net>
+Date: Wed, 26 Jun 2019 12:13:00 +0200
+Subject: [PATCH] Use OE_QMAKE_PATH_EXTERNAL_HOST_BINS to allow cmake to find
+ the rep compiler
+
+---
+ src/remoteobjects/Qt5RemoteObjectsConfigExtras.cmake.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/remoteobjects/Qt5RemoteObjectsConfigExtras.cmake.in b/src/remoteobjects/Qt5RemoteObjectsConfigExtras.cmake.in
+index 4907ded..34729da 100644
+--- a/src/remoteobjects/Qt5RemoteObjectsConfigExtras.cmake.in
++++ b/src/remoteobjects/Qt5RemoteObjectsConfigExtras.cmake.in
+@@ -40,7 +40,7 @@ if (NOT TARGET Qt5::repc)
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+     set(imported_location \"${_qt5RemoteObjects_install_prefix}/$${CMAKE_BIN_DIR}repc$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}repc$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"${OE_QMAKE_PATH_EXTERNAL_HOST_BINS}/repc${OE_QMAKE_BIN_SUFFIX}\")
+ !!ENDIF
+     _qt5_RemoteObjects_check_file_exists(${imported_location})
+ 

--- a/recipes-qt/qt5/qtremoteobjects_git.bb
+++ b/recipes-qt/qt5/qtremoteobjects_git.bb
@@ -13,9 +13,10 @@ DEPENDS += "qtbase qtdeclarative qtremoteobjects-native"
 
 # Patches from https://github.com/meta-qt5/qtremoteobjects/commits/b5.12
 # 5.12.meta-qt5.2
-SRC_URI += " \
-    file://0001-Allow-a-tools-only-build.patch \
-"
+SRC_URI = "${QT_GIT}/${QT_MODULE}.git;name=${QT_MODULE};${QT_MODULE_BRANCH_PARAM};protocol=${QT_GIT_PROTOCOL} \
+           file://0001-Allow-a-tools-only-build.patch \
+           file://0001-Use-OE_QMAKE_PATH_EXTERNAL_HOST_BINS-to-allow-cmake-.patch \
+           "
 
 PACKAGECONFIG ??= ""
 PACKAGECONFIG_class-native ??= "tools-only"


### PR DESCRIPTION
In order to allow cmake to find the rep compiler of the qtremoteobjects module during the image build this patch uses the variable OE_QMAKE_PATH_EXTERNAL_HOST_BINS instead of CMAKE_BIN_DIR to determine the location of the executable.

Please let me know if this change can introduce problems, knowing that i'm rather new into Yocto and the Qt internals.