### PR TITLE
Use OE_PATH_EXTERNAL_HOST_BINS to enable cmake to find repc

### DIFF
--- a/recipes-qt/qt5/qtremoteobjects/0001-cmake-Use-OE_QMAKE_PATH_EXTERNAL_HOST_BINS.patch
+++ b/recipes-qt/qt5/qtremoteobjects/0001-cmake-Use-OE_QMAKE_PATH_EXTERNAL_HOST_BINS.patch
@@ -1,0 +1,22 @@
+From 30d1467553f75ba94baa4569c0222c5d407f275c Mon Sep 17 00:00:00 2001
+From: ibinderwolf <daniel@bluepattern.net>
+Date: Wed, 26 Jun 2019 09:46:48 +0200
+Subject: [PATCH] cmake Use OE_QMAKE_PATH_EXTERNAL_HOST_BINS
+
+---
+ src/remoteobjects/Qt5RemoteObjectsConfigExtras.cmake.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/remoteobjects/Qt5RemoteObjectsConfigExtras.cmake.in b/src/remoteobjects/Qt5RemoteObjectsConfigExtras.cmake.in
+index 4907ded..34729da 100644
+--- a/src/remoteobjects/Qt5RemoteObjectsConfigExtras.cmake.in
++++ b/src/remoteobjects/Qt5RemoteObjectsConfigExtras.cmake.in
+@@ -40,7 +40,7 @@ if (NOT TARGET Qt5::repc)
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+     set(imported_location \"${_qt5RemoteObjects_install_prefix}/$${CMAKE_BIN_DIR}repc$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}repc$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"${OE_QMAKE_PATH_EXTERNAL_HOST_BINS}/repc${OE_QMAKE_BIN_SUFFIX}\")
+ !!ENDIF
+     _qt5_RemoteObjects_check_file_exists(${imported_location})
+ 

--- a/recipes-qt/qt5/qtremoteobjects_git.bb
+++ b/recipes-qt/qt5/qtremoteobjects_git.bb
@@ -15,6 +15,7 @@ DEPENDS += "qtbase qtdeclarative qtremoteobjects-native"
 # 5.12.meta-qt5.2
 SRC_URI += " \
     file://0001-Allow-a-tools-only-build.patch \
+    file://0001-cmake-Use-OE_QMAKE_PATH_EXTERNAL_HOST_BINS.patch \
 "
 
 PACKAGECONFIG ??= ""


### PR DESCRIPTION
In order to allow cmake to find the rep compiler of the qtremoteobjects module during the image build this patch uses the variable OE_QMAKE_PATH_EXTERNAL_HOST_BINS instead of CMAKE_BIN_DIR to determine the location of the executable.

Please let me know if this change can introduce problems, knowing that i'm rather new into Yocto and the Qt internals.