### PR TITLE
Allow enabling gui for native and nativesdk

### DIFF
--- a/classes/qmake5_base.bbclass
+++ b/classes/qmake5_base.bbclass
@@ -110,6 +110,7 @@ generate_qt_config_file_effective_paths() {
     cat >> ${OE_QMAKE_QTCONF_PATH} <<EOF
 [EffectivePaths]
 HostBinaries = ${OE_QMAKE_PATH_EXTERNAL_HOST_BINS}
+HostLibraries = ${STAGING_LIBDIR_NATIVE}
 HostData = ${OE_QMAKE_PATH_HOST_DATA}
 HostPrefix = ${STAGING_DIR_NATIVE}
 EOF

--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -66,6 +66,7 @@ FILES_${PN}-dev += " \
 
 FILES_${PN} += " \
     ${SDKPATHNATIVE}/environment-setup.d \
+    ${OE_QMAKE_PATH_PLUGINS} \
 "
 
 # qttools binaries are placed in a subdir of bin in order to avoid
@@ -73,6 +74,10 @@ FILES_${PN} += " \
 # package, since it doesn't detect binaries in subdirs. Explicitly
 # disable package auto-renaming for the tools-package.
 DEBIAN_NOAUTONAME_${PN} = "1"
+
+PACKAGECONFIG ?= ""
+PACKAGECONFIG[gui] = "-gui -qpa minimal,-no-gui,"
+PACKAGECONFIG[imageformats] = "-qt-libpng -qt-libjpeg -gif -ico, -no-libpng -no-libjpeg -no-ico -no-gif,"
 
 QT_CONFIG_FLAGS += " \
     -shared \
@@ -102,12 +107,8 @@ do_configure() {
         -no-gcc-sysroot \
         -system-zlib \
         -dbus-runtime \
-        -no-libjpeg \
-        -no-libpng \
-        -no-gif \
         -no-accessibility \
         -no-cups \
-        -no-gui \
         -no-sql-mysql \
         -no-sql-sqlite \
         -no-opengl \
@@ -149,7 +150,6 @@ do_install() {
 
     # remove things unused in nativesdk, we need the headers and libs
     rm -rf ${D}${datadir} \
-           ${D}/${OE_QMAKE_PATH_PLUGINS} \
            ${D}${libdir}/cmake \
            ${D}${libdir}/pkgconfig
 

--- a/recipes-qt/qt5/qtbase-native_git.bb
+++ b/recipes-qt/qt5/qtbase-native_git.bb
@@ -57,18 +57,18 @@ CLEANBROKEN = "1"
 XPLATFORM_toolchain-clang = "linux-oe-clang"
 XPLATFORM ?= "linux-oe-g++"
 
+PACKAGECONFIG ?= ""
+PACKAGECONFIG[gui] = "-gui -qpa minimal,-no-gui,"
+PACKAGECONFIG[imageformats] = "-qt-libpng -qt-libjpeg -gif -ico, -no-libpng -no-libjpeg -no-ico -no-gif,"
+
 QT_CONFIG_FLAGS = " \
     -sysroot ${STAGING_DIR_NATIVE} \
     -L${STAGING_LIBDIR_NATIVE} \
     -no-gcc-sysroot \
     -system-zlib \
     -qt-pcre \
-    -no-libjpeg \
-    -no-libpng \
-    -no-gif \
     -no-accessibility \
     -no-cups \
-    -no-gui \
     -no-sql-mysql \
     -no-sql-sqlite \
     -no-sql-psql \


### PR DESCRIPTION
Some Qt build tools may depend on QtGui, which need platform plugins
for running them. Use minimal platform plugin since no interaction
with the tool is expected.

Add PACKAGECONFIGs that can be used to enable gui and image format
plugins for the native and nativesdk builds.

Signed-off-by: Samuli Piippo <samuli.piippo@qt.io>