### PR TITLE
qtdeclarative: Use qmlcachegen provided by OE insead of system one.

### DIFF
--- a/recipes-qt/qt5/qtdeclarative/0001-Use-OE_QMAKE_PATH_EXTERNAL_HOST_BINS-to-locate-qmlca.patch
+++ b/recipes-qt/qt5/qtdeclarative/0001-Use-OE_QMAKE_PATH_EXTERNAL_HOST_BINS-to-locate-qmlca.patch
@@ -1,0 +1,35 @@
+From 793ddd0d9fc0d86425a0aa43709445c5ff12a464 Mon Sep 17 00:00:00 2001
+From: Piotr Tworek <tworaz@tworaz.net>
+Date: Wed, 3 Jul 2019 01:13:40 +0200
+Subject: [PATCH] Use OE_QMAKE_PATH_EXTERNAL_HOST_BINS to locate qmlcachegen
+
+Without this cmake will end up using host qmlcachegen instead of
+recipe-sysroot-native one.
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Piotr Tworek <tworaz@tworaz.net>
+---
+ tools/qmlcachegen/Qt5QuickCompilerConfig.cmake.in | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake.in b/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake.in
+index 75fbb0fcf3..1e949cd40c 100644
+--- a/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake.in
++++ b/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake.in
+@@ -18,11 +18,7 @@ function(QTQUICK_COMPILER_ADD_RESOURCES outfiles)
+ 
+     find_package(Qt5 COMPONENTS Qml Core)
+ 
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(compiler_path \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}qmlcachegen$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(compiler_path \"$${CMAKE_BIN_DIR}qmlcachegen$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
++    set(compiler_path \"${OE_QMAKE_PATH_EXTERNAL_HOST_BINS}/qmlcachegen${OE_QMAKE_BIN_SUFFIX}\")
+     if(NOT EXISTS \"${compiler_path}\" )
+         message(FATAL_ERROR \"The package \\\"Qt5QuickCompilerConfig\\\" references the file
+    \\\"${compiler_path}\\\"
+-- 
+2.21.0
+

--- a/recipes-qt/qt5/qtdeclarative_git.bb
+++ b/recipes-qt/qt5/qtdeclarative_git.bb
@@ -12,6 +12,8 @@ LIC_FILES_CHKSUM = " \
     file://LICENSE.FDL;md5=6d9f2a9af4c8b8c3c769f6cc1b6aaf7e \
 "
 
+SRC_URI += "file://0001-Use-OE_QMAKE_PATH_EXTERNAL_HOST_BINS-to-locate-qmlca.patch"
+
 DEPENDS += "qtbase"
 
 PACKAGECONFIG ??= "qml-debug qml-network ${@bb.utils.contains('DISTRO_FEATURES', 'qt5-static', 'static', '', d)}"


### PR DESCRIPTION
Right now cmake config file installed by qtdeclarative-native tries
to use system installed qmlcachegen tool. Due to this packages using qml
compiler will produce correct results only if the host system has
qmlcachegen installed and its version matches Qt version provided by OE.
If the tool is missing the package requring it will fail to build. If
its present but the version does not match OE version of Qt the package
will build fine, but in turn will fail to run on the target. Fix this by
patching Qt5QuickCompilerConfig.cmake to look for qmlcachegen in
OE_QMAKE_PATH_EXTERNAL_HOST_BINS. Similar approach is already used for
other Qt tools from qtbase-native recipe.

Signed-off-by: Piotr Tworek <tworaz@tworaz.net>