### PR TITLE
qtbase-native: Always use qt provided doubleconversion library.

### DIFF
--- a/recipes-qt/qt5/qtbase-native_git.bb
+++ b/recipes-qt/qt5/qtbase-native_git.bb
@@ -63,6 +63,7 @@ QT_CONFIG_FLAGS = " \
     -no-gcc-sysroot \
     -system-zlib \
     -qt-pcre \
+    -qt-doubleconversion \
     -no-libjpeg \
     -no-libpng \
     -no-gif \


### PR DESCRIPTION
Right now qtbase-native will try to look for double-coversion library on
the host system. If not avaiable it'll use its own copy. This means
qtbase-native binaries built on one host may fail to run on another.
Fix this by always using qt provided double-conversion library for
native qtbase builds.

Signed-off-by: Piotr Tworek <tworaz@tworaz.net>