### PR TITLE
Move colon from beginning to end

### DIFF
--- a/recipes-qt/qt5/qt5-ptest.inc
+++ b/recipes-qt/qt5/qt5-ptest.inc
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_append := ":${THISDIR}/ptest"
+FILESEXTRAPATHS_append := "${THISDIR}/ptest:"
 SRC_URI += "file://run-ptest"
 
 inherit ptest


### PR DESCRIPTION
Since the FILESEXTRAPATHS_append variable modifies the search path for src_uris, the deliminator colon should be at the end per the yocto documentation: https://www.yoctoproject.org/docs/2.4.3/ref-manual/ref-manual.html#var-FILESEXTRAPATHS

With the colon at the end, other recipes can bbappend to this recipe. without a colon at the end  (per the convention), the other recipe's path is appended to this recipe's path, causing errors during bitbake's do_fetch