### PR TITLE
qtconnectivity/qtsystems: make them zeus-compatible

### DIFF
--- a/recipes-qt/qt5/qtconnectivity_git.bb
+++ b/recipes-qt/qt5/qtconnectivity_git.bb
@@ -14,7 +14,9 @@ SRC_URI += "file://0001-Add-missing-header-for-errno.patch"
 
 DEPENDS += "qtbase qtdeclarative"
 
-inherit bluetooth
+# for zeus: bluetooth.bbclass is gone so do what it did in warrior here [1]
+# http://cgit.openembedded.org/openembedded-core/tree/meta/classes/bluetooth.bbclass?h=warrior
+BLUEZ ?= "${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', bb.utils.contains('DISTRO_FEATURES', 'bluez5', 'bluez5', 'bluez4', d), '', d)}"
 
 PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez', '', d)}"
 PACKAGECONFIG[bluez] = "-feature-bluez,-no-feature-bluez,${BLUEZ}"

--- a/recipes-qt/qt5/qtsystems_git.bb
+++ b/recipes-qt/qt5/qtsystems_git.bb
@@ -12,7 +12,9 @@ LIC_FILES_CHKSUM = " \
 
 DEPENDS += "qtbase qtdeclarative udev gconf"
 
-inherit bluetooth
+# for zeus: bluetooth.bbclass is gone so do what it did in warrior here [1]
+# http://cgit.openembedded.org/openembedded-core/tree/meta/classes/bluetooth.bbclass?h=warrior
+BLUEZ ?= "${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', bb.utils.contains('DISTRO_FEATURES', 'bluez5', 'bluez5', 'bluez4', d), '', d)}"
 
 PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez', '', d)}"
 PACKAGECONFIG[bluez] = "CONFIG+=OE_BLUEZ_ENABLED,,${BLUEZ}"


### PR DESCRIPTION
In zeus bluetooth.bbclass is gone. Replace inherit by the code of warriors's
bluetooth.bbclass.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>