### PR TITLE
pyqt5: Upgrade to 5.13.2 and fix qtwebengine build on musl

### DIFF
--- a/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bb
+++ b/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bb
@@ -108,8 +108,13 @@ RDEPENDS_${PN} += " \
     qtquickcontrols2-dev \
     qtquickcontrols2-mkspecs \
 "
+RDEPENDS_${PN}_remove_toolchain-clang_riscv32 = "qttools-dev qttools-mkspecs qttools-staticdev qttools-tools"
+RDEPENDS_${PN}_remove_toolchain-clang_riscv64 = "qttools-dev qttools-mkspecs qttools-staticdev qttools-tools"
 
 RRECOMMENDS_${PN} += " \
     qtquickcontrols-qmlplugins \
     qttools-plugins \
 "
+
+RRECOMMENDS_${PN}_remove_toolchain-clang_riscv32 = "qttools-plugins"
+RRECOMMENDS_${PN}_remove_toolchain-clang_riscv64 = "qttools-plugins"

--- a/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bb
+++ b/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bb
@@ -3,6 +3,7 @@
 DESCRIPTION = "Target packages for Qt5 SDK"
 LICENSE = "MIT"
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"

--- a/recipes-qt/qmllive/qmllive/0001-lib.pro-Append-LIB_ARCH-to-lib.patch
+++ b/recipes-qt/qmllive/qmllive/0001-lib.pro-Append-LIB_ARCH-to-lib.patch
@@ -1,0 +1,39 @@
+From 647b1da38d8c741681de9c89f2090f0edcf25a47 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 19 Dec 2019 13:40:34 -0800
+Subject: [PATCH] lib.pro: Append LIB_ARCH to lib
+
+appending to lib so it becomes lib64 when needed and LIB_ARCH can be set
+in evnironment
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/lib.pro | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib.pro b/src/lib.pro
+index b5f8ab6..0731d01 100755
+--- a/src/lib.pro
++++ b/src/lib.pro
+@@ -18,7 +18,7 @@ public_headers += \
+ include(src.pri)
+ 
+ win32: target.path = $${PREFIX}/bin
+-else: target.path = $${PREFIX}/lib
++else: target.path = $${PREFIX}/lib$${LIB_ARCH}
+ INSTALLS += target
+ 
+ headers.files = $$public_headers
+@@ -30,7 +30,7 @@ INSTALLS += headers
+     QMAKE_PKGCONFIG_NAME = qmllive
+     QMAKE_PKGCONFIG_DESCRIPTION = Qt QmlLive Library
+     QMAKE_PKGCONFIG_PREFIX = $$PREFIX
+-    QMAKE_PKGCONFIG_LIBDIR = ${prefix}/lib
++    QMAKE_PKGCONFIG_LIBDIR = ${prefix}/lib$${LIB_ARCH}
+     QMAKE_PKGCONFIG_INCDIR = ${prefix}/include/qmllive
+     QMAKE_PKGCONFIG_DESTDIR = pkgconfig
+ }
+-- 
+2.24.1
+

--- a/recipes-qt/qmllive/qmllive_git.bb
+++ b/recipes-qt/qmllive/qmllive_git.bb
@@ -7,12 +7,15 @@ DEPENDS = "qtbase qtdeclarative"
 PV = "5.12+git${SRCPV}"
 
 QT_GIT_PROJECT = "qt-apps"
-SRC_URI = "${QT_GIT}/qmllive.git;branch=dev"
+SRC_URI = "${QT_GIT}/qmllive.git;branch=dev \
+           file://0001-lib.pro-Append-LIB_ARCH-to-lib.patch \
+          "
 SRCREV = "0c7bf141b08aa9e757e91a4a05769257d043eab2"
 S = "${WORKDIR}/git"
 
 inherit pkgconfig qmake5
 
+EXTRA_QMAKEVARS_PRE += "LIB_ARCH=${@d.getVar('baselib').replace('lib', '')}"
 EXTRA_QMAKEVARS_POST = "QMAKE_RPATHDIR="
 
 FILES_${PN}-dev += "${datadir}"

--- a/recipes-qt/qt5/ogl-runtime_git.bb
+++ b/recipes-qt/qt5/ogl-runtime_git.bb
@@ -14,6 +14,8 @@ QT_MODULE_BRANCH_EASTL = "master"
 QT_GIT_PROJECT = "qt3dstudio"
 PV = "2.4+git${SRCPV}"
 
+COMPATIBLE_HOST = "(i.86|x86_64|aarch64|arm|powerpc64).*-linux"
+
 SRC_URI += " \
     ${QT_GIT}/qt3dstudio-eastl.git;name=EASTL;branch=${QT_MODULE_BRANCH_EASTL};protocol=${QT_GIT_PROTOCOL};destsuffix=git/src/3rdparty/EASTL \
     file://0001-Fix-examples-build-error.patch \

--- a/recipes-qt/qt5/qt5-creator/0001-clangformat-AllowShortIfStatementsOnASingleLine-is-n.patch
+++ b/recipes-qt/qt5/qt5-creator/0001-clangformat-AllowShortIfStatementsOnASingleLine-is-n.patch
@@ -18,19 +18,36 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  src/plugins/clangformat/clangformatutils.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/src/plugins/clangformat/clangformatutils.cpp b/src/plugins/clangformat/clangformatutils.cpp
-index 09a3150c89..7d8a95ae18 100644
 --- a/src/plugins/clangformat/clangformatutils.cpp
 +++ b/src/plugins/clangformat/clangformatutils.cpp
-@@ -60,7 +60,7 @@ static clang::format::FormatStyle qtcStyle()
+@@ -57,10 +57,18 @@ static clang::format::FormatStyle qtcSty
+     style.AlignOperands = true;
+     style.AlignTrailingComments = true;
+     style.AllowAllParametersOfDeclarationOnNextLine = true;
++#if Q_CC_CLANG < 1000
      style.AllowShortBlocksOnASingleLine = false;
++#else
++    style.AllowShortBlocksOnASingleLine = FormatStyle::SBS_Never;
++#endif
      style.AllowShortCaseLabelsOnASingleLine = false;
      style.AllowShortFunctionsOnASingleLine = FormatStyle::SFS_Inline;
--    style.AllowShortIfStatementsOnASingleLine = false;
++#if Q_CC_CLANG < 900
+     style.AllowShortIfStatementsOnASingleLine = false;
++#else
 +    style.AllowShortIfStatementsOnASingleLine = FormatStyle::SIS_Never;
++#endif
      style.AllowShortLoopsOnASingleLine = false;
      style.AlwaysBreakAfterReturnType = FormatStyle::RTBS_None;
      style.AlwaysBreakBeforeMultilineStrings = false;
--- 
-2.23.0
-
+@@ -68,7 +76,11 @@ static clang::format::FormatStyle qtcSty
+     style.BinPackArguments = false;
+     style.BinPackParameters = false;
+     style.BraceWrapping.AfterClass = true;
++#if Q_CC_CLANG < 1000
+     style.BraceWrapping.AfterControlStatement = false;
++#else
++    style.BraceWrapping.AfterControlStatement = FormatStyle::BWACS_Never;
++#endif
+     style.BraceWrapping.AfterEnum = false;
+     style.BraceWrapping.AfterFunction = true;
+     style.BraceWrapping.AfterNamespace = false;

--- a/recipes-qt/qt5/qt5-creator_git.bb
+++ b/recipes-qt/qt5/qt5-creator_git.bb
@@ -35,6 +35,9 @@ EXTRA_QMAKEVARS_PRE += "IDE_LIBRARY_BASENAME=${baselib}${QT_DIR_NAME}"
 
 EXTRANATIVEPATH += "chrpath-native"
 
+COMPATIBLE_HOST_toolchain-clang_riscv32 = "null"
+COMPATIBLE_HOST_toolchain-clang_riscv64 = "null"
+
 do_configure_append() {
     # Find native tools
     sed -i 's:${STAGING_BINDIR}.*/qdoc:${OE_QMAKE_PATH_EXTERNAL_HOST_BINS}/qdoc:g' ${B}/Makefile

--- a/recipes-qt/qt5/qttools/0003-src.pro-Add-option-noqdoc-to-disable-qdoc-builds.patch
+++ b/recipes-qt/qt5/qttools/0003-src.pro-Add-option-noqdoc-to-disable-qdoc-builds.patch
@@ -1,0 +1,28 @@
+From 623675e07231f62cdc7600dca5897a9fc70e0467 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 14 Dec 2019 18:36:49 -0800
+Subject: [PATCH] src.pro: Add option noqdoc to disable qdoc builds
+
+it needs clang on host, so lets separate it out
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/src.pro | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/src.pro b/src/src.pro
+index 5c256ea3..196c34c7 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -25,7 +25,7 @@ qtConfig(library) {
+ 
+ include($$OUT_PWD/qdoc/qtqdoc-config.pri)
+ QT_FOR_CONFIG += qdoc-private
+-qtConfig(qdoc): qtConfig(thread): SUBDIRS += qdoc
++qtConfig(qdoc): qtConfig(thread):!contains(CONFIG, noqdoc): SUBDIRS += qdoc
+ 
+ !android|android_app: SUBDIRS += qtpaths
+ 
+-- 
+2.24.1
+

--- a/recipes-qt/qt5/qttools_git.bb
+++ b/recipes-qt/qt5/qttools_git.bb
@@ -18,6 +18,7 @@ DEPENDS += "qtbase qtdeclarative qtxmlpatterns"
 SRC_URI += " \
     file://0001-add-noqtwebkit-configuration.patch \
     file://0002-linguist-tools-cmake-allow-overriding-the-location-f.patch \
+    file://0003-src.pro-Add-option-noqdoc-to-disable-qdoc-builds.patch \
 "
 
 FILES_${PN}-tools += "${datadir}${QT_DIR_NAME}/phrasebooks"
@@ -34,9 +35,14 @@ COMPATIBLE_HOST_toolchain-clang_riscv64 = "null"
 
 export YOCTO_ALTERNATE_EXE_PATH = "${STAGING_BINDIR}/llvm-config"
 
+TOOLSTOBUILD += "linguist/lconvert linguist/lrelease linguist/lupdate pixeltool qtdiag qtpaths qtplugininfo"
+TOOLSTOBUILD += "${@bb.utils.contains('PACKAGECONFIG', 'clang', 'qdoc', '', d)}"
+TOOLSFORTARGET = "pixeltool qtdiag qtpaths qtplugininfo"
+TOOLSFORHOST = "linguist ${@bb.utils.contains('PACKAGECONFIG', 'clang', 'qdoc', '', d)}"
+
 EXTRA_QMAKEVARS_PRE += " \
     ${@bb.utils.contains('PACKAGECONFIG', 'qtwebkit', '', 'CONFIG+=noqtwebkit', d)} \
-    CONFIG+=disable_external_rpath \
+    ${@bb.utils.contains('PACKAGECONFIG', 'clang', 'CONFIG+=disable_external_rpath', 'CONFIG+=noqdoc', d)} \
 "
 EXTRA_QMAKEVARS_PRE_append_class-native = " CONFIG+=config_clang_done CONFIG-=config_clang"
 EXTRA_QMAKEVARS_PRE_append_class-nativesdk = " CONFIG+=config_clang_done CONFIG-=config_clang"

--- a/recipes-qt/qt5/qttools_git.bb
+++ b/recipes-qt/qt5/qttools_git.bb
@@ -30,6 +30,9 @@ PACKAGECONFIG_append_toolchain-clang = " clang"
 PACKAGECONFIG[qtwebkit] = ",,qtwebkit"
 PACKAGECONFIG[clang] = ",,clang"
 
+COMPATIBLE_HOST_toolchain-clang_riscv32 = "null"
+COMPATIBLE_HOST_toolchain-clang_riscv64 = "null"
+
 export YOCTO_ALTERNATE_EXE_PATH = "${STAGING_BINDIR}/llvm-config"
 
 EXTRA_QMAKEVARS_PRE += " \

--- a/recipes-qt/qt5/qttools_git.bb
+++ b/recipes-qt/qt5/qttools_git.bb
@@ -12,8 +12,7 @@ LIC_FILES_CHKSUM = " \
     file://LICENSE.FDL;md5=6d9f2a9af4c8b8c3c769f6cc1b6aaf7e \
 "
 
-DEPENDS += "qtbase qtdeclarative qtxmlpatterns chrpath-replacement-native"
-EXTRANATIVEPATH += "chrpath-native"
+DEPENDS += "qtbase qtdeclarative qtxmlpatterns"
 # Patches from https://github.com/meta-qt5/qttools/commits/b5.13
 # 5.13.meta-qt5.1
 SRC_URI += " \
@@ -37,6 +36,7 @@ export YOCTO_ALTERNATE_EXE_PATH = "${STAGING_BINDIR}/llvm-config"
 
 EXTRA_QMAKEVARS_PRE += " \
     ${@bb.utils.contains('PACKAGECONFIG', 'qtwebkit', '', 'CONFIG+=noqtwebkit', d)} \
+    CONFIG+=disable_external_rpath \
 "
 EXTRA_QMAKEVARS_PRE_append_class-native = " CONFIG+=config_clang_done CONFIG-=config_clang"
 EXTRA_QMAKEVARS_PRE_append_class-nativesdk = " CONFIG+=config_clang_done CONFIG-=config_clang"
@@ -52,7 +52,4 @@ do_install_ptest() {
     mkdir -p ${D}${PTEST_PATH}
     t=${D}${PTEST_PATH}
     cp ${B}/tests/auto/qtdiag/tst_tdiag $t
-}
-do_install_append_toolchain-clang() {
-    chrpath --delete ${D}${bindir}/qdoc
 }

--- a/recipes-qt/qt5/qtwebengine/chromium/0022-chromium-Include-cstddef-for-size_t-definition.patch
+++ b/recipes-qt/qt5/qtwebengine/chromium/0022-chromium-Include-cstddef-for-size_t-definition.patch
@@ -1,0 +1,43 @@
+From 409a3764e31f3c3db4087fbd2a401c950e6e041d Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 25 Dec 2019 15:41:16 -0800
+Subject: [PATCH] chromium: Include cstddef for size_t definition
+
+Include ctsdint for uintXX_t
+
+Fixes
+In file included from ../../../../git/src/3rdparty/chromium/third_party/webrtc/modules/audio_processing/aec3/clockdrift_detector.cc:10:
+../../../../git/src/3rdparty/chromium/third_party/webrtc/modules/audio_processing/aec3/clockdrift_detector.h:34:3: error: 'size_t' does not name a type
+   34 |   size_t stability_counter_;
+      |   ^~~~~~
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+ccc
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../webrtc/modules/audio_processing/aec3/clockdrift_detector.h   | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/chromium/third_party/webrtc/modules/audio_processing/aec3/clockdrift_detector.h
++++ b/chromium/third_party/webrtc/modules/audio_processing/aec3/clockdrift_detector.h
+@@ -12,6 +12,7 @@
+ #define MODULES_AUDIO_PROCESSING_AEC3_CLOCKDRIFT_DETECTOR_H_
+ 
+ #include <array>
++#include <cstddef>
+ 
+ namespace webrtc {
+ 
+--- a/chromium/third_party/webrtc/modules/video_coding/decoding_state.h
++++ b/chromium/third_party/webrtc/modules/video_coding/decoding_state.h
+@@ -14,6 +14,7 @@
+ #include <map>
+ #include <set>
+ #include <vector>
++#include <cstdint>
+ 
+ namespace webrtc {
+ 

--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -160,6 +160,7 @@ SRC_URI += " \
     file://chromium/0006-chromium-aarch64-skia-build-fix.patch;patchdir=src/3rdparty \
     file://chromium/0007-chromium-fix-build-after-y2038-changes-in-glibc.patch;patchdir=src/3rdparty \
     file://chromium/0021-chromium-Fix-build-on-32bit-arches-with-64bit-time_t.patch;patchdir=src/3rdparty \
+    file://chromium/0022-chromium-Include-cstddef-for-size_t-definition.patch;patchdir=src/3rdparty \
 "
 
 SRC_URI_append_libc-musl = "\

--- a/recipes-qt/qt5/qtwebkit_git.bb
+++ b/recipes-qt/qt5/qtwebkit_git.bb
@@ -49,9 +49,13 @@ EXTRA_OECMAKE += " \
 
 EXTRA_OECMAKE_append_toolchain-clang = " -DCMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES:PATH='${STAGING_INCDIR}'"
 
-# JIT not supported on MIPS64
-EXTRA_OECMAKE_append_mips64 = " -DENABLE_JIT=OFF "
-EXTRA_OECMAKE_append_mips64el = " -DENABLE_JIT=OFF "
+# JIT not supported on MIPS/PPC
+EXTRA_OECMAKE_append_mipsarch = " -DENABLE_JIT=OFF -DENABLE_C_LOOP=ON "
+EXTRA_OECMAKE_append_powerpc = " -DENABLE_JIT=OFF -DENABLE_C_LOOP=ON "
+# Disable gold on mips64/clang
+# mips64-yoe-linux-musl-ld.gold: internal error in get_got_page_offset, at ../../gold/mips.cc:6260
+# mips-yoe-linux-musl-ld.gold: error: Can't find matching LO16 reloc
+EXTRA_OECMAKE_append_toolchain-clang_mipsarch = " -DUSE_LD_GOLD=OFF "
 
 PACKAGECONFIG ??= "qtlocation qtmultimedia qtsensors qtwebchannel \
     ${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)} \

--- a/recipes-qt/quazip/quazip/0001-Append-LIB_ARCH-to-lib.patch
+++ b/recipes-qt/quazip/quazip/0001-Append-LIB_ARCH-to-lib.patch
@@ -1,0 +1,31 @@
+From 7bcf47c1d9ca5eb27da088f93387e42b55d6999c Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 19 Dec 2019 13:22:38 -0800
+Subject: [PATCH] Append LIB_ARCH to lib
+
+Creating subdir under lib is not expected in OE, instead it should be
+appending to lib so it becomes lib64 when needed and LIB_ARCH can be set
+in evnironment
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ quazip/quazip.pro | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/quazip/quazip.pro b/quazip/quazip.pro
+index 3e10f36..1ea073e 100644
+--- a/quazip/quazip.pro
++++ b/quazip/quazip.pro
+@@ -42,7 +42,7 @@ CONFIG(debug, debug|release) {
+ unix:!symbian {
+     headers.path=$$PREFIX/include/quazip
+     headers.files=$$HEADERS
+-    target.path=$$PREFIX/lib/$${LIB_ARCH}
++    target.path=$$PREFIX/lib$${LIB_ARCH}
+     INSTALLS += headers target
+ 
+ 	OBJECTS_DIR=.obj
+-- 
+2.24.1
+

--- a/recipes-qt/quazip/quazip_0.7.3.bb
+++ b/recipes-qt/quazip/quazip_0.7.3.bb
@@ -5,11 +5,13 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=910d778aab53617cbaf13c4e1810e289"
 DEPENDS = "qtbase"
 
-SRC_URI = "${SOURCEFORGE_MIRROR}/${BPN}/${BP}.tar.gz"
+SRC_URI = "${SOURCEFORGE_MIRROR}/${BPN}/${BP}.tar.gz \
+           file://0001-Append-LIB_ARCH-to-lib.patch \
+          "
 SRC_URI[md5sum] = "2ba7dd8b1d6dd588374c9fab5c46e76e"
 SRC_URI[sha256sum] = "2ad4f354746e8260d46036cde1496c223ec79765041ea28eb920ced015e269b5"
 
 inherit qmake5
 
-EXTRA_QMAKEVARS_PRE += "PREFIX=${prefix}"
+EXTRA_QMAKEVARS_PRE += "PREFIX=${prefix} LIB_ARCH=${@d.getVar('baselib').replace('lib', '')}"
 EXTRA_QMAKEVARS_POST += "SUBDIRS=${BPN}"

--- a/recipes-qt/qwt/qwt-qt5_6.1.4.bb
+++ b/recipes-qt/qwt/qwt-qt5_6.1.4.bb
@@ -8,6 +8,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=dac2743472b0462ff3cfb4af42051c88"
 
 DEPENDS = "qtbase qtsvg qttools"
 
+COMPATIBLE_HOST_toolchain-clang_riscv32 = "null"
+COMPATIBLE_HOST_toolchain-clang_riscv64 = "null"
+
 inherit qmake5
 
 SRC_URI = " \


### PR DESCRIPTION
Blacklist py2 version, it does not build and py2 is on its way out in
Jan 2020 anyway

Signed-off-by: Khem Raj <raj.khem@gmail.com>