### PR TITLE
silence warning: inherit features_check instead of deprecated distro_…

### DIFF
--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -81,7 +81,7 @@ inherit qmake5
 inherit gettext
 inherit pythonnative
 inherit perlnative
-inherit distro_features_check
+inherit features_check
 
 # Static builds of QtWebEngine aren't supported.
 CONFLICT_DISTRO_FEATURES = "qt5-static"


### PR DESCRIPTION
openembedded renamed **distro_features_check.bbclass** to **features_check.bbclass**.
They still provide the functionality under the old name, but bitbake will emit a warning.
This commit silences said warning.