### PR TITLE
nativesdk-packagegroup: fix cmake builds using sdk

### DIFF
--- a/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
+++ b/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
@@ -11,5 +11,6 @@ RDEPENDS_${PN} += " \
     nativesdk-packagegroup-sdk-host \
     nativesdk-qttools-tools \
     nativesdk-qtbase \
+    nativesdk-qtbase-dev \
     nativesdk-perl-modules \
 "


### PR DESCRIPTION
The cmake toolchain init files are packaged into nativesdk-qtbase-dev.

Signed-off-by: Marc Reilly <marc@cpdesign.com.au>