### PR TITLE
qt5-creator: Update musl patch to link qmldesigner with -lexecinfo

### DIFF
--- a/recipes-qt/qt5/qtbase/0018-input-Make-use-of-timeval-portable-for-64bit-time_t.patch
+++ b/recipes-qt/qt5/qtbase/0018-input-Make-use-of-timeval-portable-for-64bit-time_t.patch
@@ -13,8 +13,6 @@ Change-Id: Ie4d66a5e7d83065f1a904a542c711431e1d20845
 
 ---
 
-diff --git a/src/platformsupport/input/evdevkeyboard/qevdevkeyboardhandler.cpp b/src/platformsupport/input/evdevkeyboard/qevdevkeyboardhandler.cpp
-index 3555763..e7dc57c 100644
 --- a/src/platformsupport/input/evdevkeyboard/qevdevkeyboardhandler.cpp
 +++ b/src/platformsupport/input/evdevkeyboard/qevdevkeyboardhandler.cpp
 @@ -58,6 +58,11 @@
@@ -29,8 +27,8 @@ index 3555763..e7dc57c 100644
  QT_BEGIN_NAMESPACE
  
  Q_LOGGING_CATEGORY(qLcEvdevKey, "qt.qpa.input")
-@@ -150,7 +155,10 @@
-     qCDebug(qLcEvdevKey, "switchLed %d %d", led, int(state));
+@@ -149,7 +154,10 @@ void QEvdevKeyboardHandler::switchLed(in
+     qCDebug(qLcEvdevKey) << "switchLed" << led << state;
  
      struct ::input_event led_ie;
 -    ::gettimeofday(&led_ie.time, 0);
@@ -41,11 +39,9 @@ index 3555763..e7dc57c 100644
      led_ie.type = EV_LED;
      led_ie.code = led;
      led_ie.value = state;
-diff --git a/src/platformsupport/input/evdevtouch/qevdevtouchhandler.cpp b/src/platformsupport/input/evdevtouch/qevdevtouchhandler.cpp
-index 78728ef..1d65f9b 100644
 --- a/src/platformsupport/input/evdevtouch/qevdevtouchhandler.cpp
 +++ b/src/platformsupport/input/evdevtouch/qevdevtouchhandler.cpp
-@@ -58,6 +58,11 @@
+@@ -55,6 +55,11 @@
  #include <linux/input.h>
  #endif
  
@@ -57,7 +53,7 @@ index 78728ef..1d65f9b 100644
  #include <math.h>
  
  #if QT_CONFIG(mtdev)
-@@ -573,7 +578,7 @@
+@@ -568,7 +573,7 @@ void QEvdevTouchScreenData::processInput
  
          // update timestamps
          m_lastTimeStamp = m_timeStamp;


### PR DESCRIPTION
Fixes link failures like below

src/plugins/qmldesigner/designercore/exceptions/exception.cpp:116: undefined reference to `backtrace'

Signed-off-by: Khem Raj <raj.khem@gmail.com>