### PR TITLE
Revert "recipes: Use features_check instead of distro_features_check"

### DIFF
--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -80,7 +80,7 @@ COMPATIBLE_MACHINE_aarch64 = "(.*)"
 inherit qmake5
 inherit gettext
 inherit perlnative
-inherit features_check
+inherit distro_features_check
 
 inherit ${@bb.utils.contains("BBFILE_COLLECTIONS", "meta-python2", "pythonnative", "", d)}
 


### PR DESCRIPTION
This reverts commit b7f4bd209c03c4f765cec84f4aa247819a6bb2f3.

The features_check class was renamed to distro_features_check and you
will get a warning about the deprecation for now. But the old name is still
valid and for some Poky versions, you should still be able to build
newer versions of this meta layer.