### PR TITLE
qtwebview: Skip if meta-python is not present

### DIFF
--- a/recipes-qt/qt5/qtwebview_git.bb
+++ b/recipes-qt/qt5/qtwebview_git.bb
@@ -20,3 +20,9 @@ COMPATIBLE_MACHINE_armv7ve = "(.*)"
 COMPATIBLE_MACHINE_aarch64 = "(.*)"
 
 SRCREV = "94c697c37945dedb37a55c1a9669d868f8c97f41"
+
+python() {
+    if 'meta-python2' not in d.getVar('BBFILE_COLLECTIONS').split():
+        raise bb.parse.SkipRecipe('Requires meta-python2 to be present.')
+}
+


### PR DESCRIPTION
It needs qtwebengine which needs python2 so skip it when python2 is not
present

Signed-off-by: Khem Raj <raj.khem@gmail.com>