### PR TITLE
Remove PyQt_qreal_double from DISABLED_FEATURES

### DIFF
--- a/recipes-python/pyqt5/python-pyqt5.inc
+++ b/recipes-python/pyqt5/python-pyqt5.inc
@@ -26,8 +26,6 @@ PARALLEL_MAKEINST = ""
 
 DISABLED_FEATURES = "PyQt_Desktop_OpenGL PyQt_Accessibility PyQt_SessionManager"
 
-DISABLED_FEATURES_append_arm = " PyQt_qreal_double"
-
 PYQT_MODULES = "QtCore QtGui QtNetwork QtWidgets QtXml QtNetwork QtQml QtQuick QtQuickWidgets"
 
 do_configure_prepend() {

--- a/recipes-python/pyqtchart/python-pyqtchart.inc
+++ b/recipes-python/pyqtchart/python-pyqtchart.inc
@@ -25,8 +25,6 @@ PARALLEL_MAKEINST = ""
 
 DISABLED_FEATURES = "PyQt_Desktop_OpenGL PyQt_Accessibility PyQt_SessionManager"
 
-DISABLED_FEATURES_append_arm = " PyQt_qreal_double"
-
 do_configure_prepend() {
     cd ${S}
     echo "[PyQt 5]" > pyqt.cfg


### PR DESCRIPTION
Since Qt 5.2.0 the qreal is double (see change [d8bf317546bc](https://github.com/qt/qtbase/commit/d8bf317546bcfab0b6b50375218429fa9d470705) in qtbase.git).