### PR TITLE
layer: Mark dunfell as the only compatible release

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_qt5-layer = "1"
 
 LAYERDEPENDS_qt5-layer = "core"
 
-LAYERSERIES_COMPAT_qt5-layer = "sumo thud warrior zeus"
+LAYERSERIES_COMPAT_qt5-layer = "dunfell"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 


### PR DESCRIPTION
* there are couple things people need to provide to even parse
  meta-qt5 dunfell branch with older than dunfell release of oe-core
  so I don't want to mark it as compatible, people who understand how
  to provide these missing bits will know how to override
  LAYERSERIES_COMPAT_qt5-layer from their own layer (which needs to
  be parsed before meta-qt5 layer - I suggest to use something like
  separate meta-qt5-compat layer)

  the required work arounds (these are the examples to build dunfell
  branch from zeus:

  1) mime-xdg.bbclass, e.g.:
  https://github.com/webOS-ports/meta-webos-ports/commit/e57440cb97b210e86991dd0ff2ec53c50d6e0494
  2) gstreamer1.0-plugins-good PACKAGECONFIG:
  https://github.com/webOS-ports/meta-webos-ports/commit/75fd06799bf32eca6700bdf6066d509cf36f3049
  3) meta-python2:
  https://github.com/webOS-ports/meta-webos-ports/commit/57f3f6f20b8c9911042abf0cbf2983df97eb8465
  4) features_check.bbclass:
  https://github.com/webOS-ports/meta-webos-ports/commit/fb3e94ba4a200eaba989a2871a4a5344e2162278

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>