### PR TITLE
qtwebengine: Remove python2 dependency

### DIFF
--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -82,14 +82,6 @@ inherit gettext
 inherit perlnative
 inherit features_check
 
-inherit ${@bb.utils.contains("BBFILE_COLLECTIONS", "meta-python2", "pythonnative", "", d)}
-
-python() {
-    if 'meta-python2' not in d.getVar('BBFILE_COLLECTIONS').split():
-        raise bb.parse.SkipRecipe('Requires meta-python2 to be present.')
-}
-
-
 # Static builds of QtWebEngine aren't supported.
 CONFLICT_DISTRO_FEATURES = "qt5-static"
 


### PR DESCRIPTION
python2 is deprecated in yocto and this is not necessary here.

Fixed #297

Signed-off-by: Changhyeok Bae <changhyeok.bae@gmail.com>