### PR TITLE
[zeus] qtwayland: Backport fix for newer mesa

### DIFF
--- a/recipes-qt/qt5/qtwayland/0002-Fix-compilation-of-linuxdmabuf-compositor-plugin.patch
+++ b/recipes-qt/qt5/qtwayland/0002-Fix-compilation-of-linuxdmabuf-compositor-plugin.patch
@@ -1,0 +1,32 @@
+From 7514d07ef6ccccde9cbfd466113943098591ff03 Mon Sep 17 00:00:00 2001
+From: Johan Klokkhammer Helsing <johan.helsing@qt.io>
+Date: Fri, 8 Nov 2019 13:58:04 +0100
+Subject: [PATCH] Fix compilation of linuxdmabuf compositor plugin
+
+Mesa's eglext.h no longer includes eglmesaext.h, so copy over the typedefs we need.
+
+Fixes: QTBUG-79709
+Change-Id: I3190ef56e0e162636efea440dff7e760cf11fcd0
+Upstream-Status: Backport [c2105d8b7e16cc934b886537968228f6300bf4bc]
+---
+ .../compositor/linux-dmabuf-unstable-v1/linuxdmabuf.h         | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/hardwareintegration/compositor/linux-dmabuf-unstable-v1/linuxdmabuf.h b/src/hardwareintegration/compositor/linux-dmabuf-unstable-v1/linuxdmabuf.h
+index 2abc2ce6..f9188588 100644
+--- a/src/hardwareintegration/compositor/linux-dmabuf-unstable-v1/linuxdmabuf.h
++++ b/src/hardwareintegration/compositor/linux-dmabuf-unstable-v1/linuxdmabuf.h
+@@ -68,6 +68,10 @@
+ #define DRM_FORMAT_MOD_INVALID  fourcc_mod_code(NONE, DRM_FORMAT_RESERVED)
+ #endif
+ 
++// Copied from eglmesaext.h
++typedef EGLBoolean (EGLAPIENTRYP PFNEGLBINDWAYLANDDISPLAYWL) (EGLDisplay dpy, struct wl_display *display);
++typedef EGLBoolean (EGLAPIENTRYP PFNEGLUNBINDWAYLANDDISPLAYWL) (EGLDisplay dpy, struct wl_display *display);
++
+ QT_BEGIN_NAMESPACE
+ 
+ class QWaylandCompositor;
+-- 
+2.24.0
+

--- a/recipes-qt/qt5/qtwayland_git.bb
+++ b/recipes-qt/qt5/qtwayland_git.bb
@@ -13,7 +13,10 @@ LIC_FILES_CHKSUM = " \
     file://LICENSE.FDL;md5=6d9f2a9af4c8b8c3c769f6cc1b6aaf7e \
 "
 
-SRC_URI += "file://0001-tst_seatv4-Include-array.patch"
+SRC_URI += " \
+	file://0001-tst_seatv4-Include-array.patch \
+	file://0002-Fix-compilation-of-linuxdmabuf-compositor-plugin.patch \
+	"
 
 PACKAGECONFIG ?= " \
     wayland-client \


### PR DESCRIPTION
The qtwayland fails to build without this patch with newer Mesa 20.0.y,
add the backport to permit the build to pass.

The fix is for QTBUG-79709,
https://bugreports.qt.io/browse/QTBUG-79709