### PR TITLE
qtbase: fix umask for do_generate_qt_environment_file

### DIFF
--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -198,6 +198,7 @@ fakeroot do_generate_qt_environment_file() {
     sed -i -e 's:${SDKPATHNATIVE}:$OECORE_NATIVE_SYSROOT:g' $script
 }
 
+do_generate_qt_environment_file[umask] = "022"
 addtask generate_qt_environment_file after do_install before do_package
 
 SRCREV = "86b933c430eafcaa90f1e56b91a62d3c6c228e5e"


### PR DESCRIPTION
The custom task "do_generate_qt_environment_file" generates the
directory "environment-setup.d" with permission 775 instead of 755.
When other recipes populate the same directory with different
permissions, a package manager like RPM will report this as an error.

The solution is to either set the installation permissions explicitly
with "install -d [-m 755]", or specify the umask for the custom task.

This commit uses the latter approach and fixes errors like the following
when trying to generate an SDK:

  $ bitbake <image-with-qt5> -c populate_sdk
  [...]
  Error: Transaction check error:
    file /opt/poky/2.4.2/sysroots/x86_64-pokysdk-linux/environment-setup.d
    conflicts between attempted installs of
    nativesdk-cmake-3.8.2-r0.x86_64_nativesdk and
    nativesdk-qtbase-tools-5.9.4+git0+0d9208cecb-r0.x86_64_nativesdk

A detailed discussion about this problem can also be found here [1].

[1] https://stackoverflow.com/a/49003464

Same issue in rocko.

Signed-off-by: Dennis Menschel <menschel-d@posteo.de>
Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
Signed-off-by: Jeremy A. Puhlman <jpuhlman@mvista.com>