### PR TITLE
gstreamer1.0-plugins-good: Reemove inserting qt5 from packageconfig

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG_append = " qt5"


### PR DESCRIPTION
layers are usually supposed to be inert, but this option automatically
inserts itself without any changes due to this bbappend. Its best to
leeave this option to end user to enable, defaults are to disable it and
let it be as it is.

Signed-off-by: Khem Raj <raj.khem@gmail.com>