### PR TITLE
maliit-framework-qt5: fix postinst/postrm scripts

### DIFF
--- a/recipes-qt/maliit/maliit-framework-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-framework-qt5_git.bb
@@ -75,13 +75,11 @@ do_install_append() {
     install -m 644 ${WORKDIR}/maliit-server.desktop ${D}${datadir}/applications
 }
 
-pkg_postinst_${PN} () {
+pkg_postinst_ontarget_${PN} () {
 #!/bin/sh
 # should run online
-if [ "x$D" = "x" ]; then
-    echo "export QT_IM_MODULE=Maliit" >> /etc/xprofile
-    ln -s /usr/share/applications/maliit-server.desktop /etc/xdg/autostart/maliit-server.desktop
-fi
+echo "export QT_IM_MODULE=Maliit" >> /etc/xprofile
+ln -s /usr/share/applications/maliit-server.desktop /etc/xdg/autostart/maliit-server.desktop
 }
 
 pkg_postrm_${PN} () {

--- a/recipes-qt/maliit/maliit-framework-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-framework-qt5_git.bb
@@ -79,22 +79,24 @@ pkg_postinst_${PN} () {
 #!/bin/sh
 # should run online
 if [ "x$D" != "x" ]; then
-    exit 1
+    :
+else
+    echo "export QT_IM_MODULE=Maliit" >> /etc/xprofile
+    ln -s /usr/share/applications/maliit-server.desktop /etc/xdg/autostart/maliit-server.desktop
 fi
-echo "export QT_IM_MODULE=Maliit" >> /etc/xprofile
-ln -s /usr/share/applications/maliit-server.desktop /etc/xdg/autostart/maliit-server.desktop
 }
 
 pkg_postrm_${PN} () {
 #!/bin/sh
 # should run online
 if [ "x$D" = "x" ]; then
-    exit 1
+    :
+else
+    if [ -e "/etc/xprofile" ]; then
+        sed -i -e "g|export QT_IM_MODULE=Maliit|d" /etc/xprofile
+    fi
+    rm -f /etc/xdg/autostart/maliit-server.desktop
 fi
-if [ -e "/etc/xprofile" ]; then
-    sed -i -e "g|export QT_IM_MODULE=Maliit|d" /etc/xprofile
-fi
-rm -f /etc/xdg/autostart/maliit-server.desktop
 }
 
 S = "${WORKDIR}/git"

--- a/recipes-qt/maliit/maliit-framework-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-framework-qt5_git.bb
@@ -78,9 +78,7 @@ do_install_append() {
 pkg_postinst_${PN} () {
 #!/bin/sh
 # should run online
-if [ "x$D" != "x" ]; then
-    :
-else
+if [ "x$D" = "x" ]; then
     echo "export QT_IM_MODULE=Maliit" >> /etc/xprofile
     ln -s /usr/share/applications/maliit-server.desktop /etc/xdg/autostart/maliit-server.desktop
 fi
@@ -90,8 +88,6 @@ pkg_postrm_${PN} () {
 #!/bin/sh
 # should run online
 if [ "x$D" = "x" ]; then
-    :
-else
     if [ -e "/etc/xprofile" ]; then
         sed -i -e "g|export QT_IM_MODULE=Maliit|d" /etc/xprofile
     fi


### PR DESCRIPTION
ERROR: do_rootfs: Postinstall scriptlets of ['maliit-framework-qt5'] have failed. If the intention is to defer them to first boot,
then please place them into pkg_postinst_ontarget_${PN} ().
Deferring to first boot via 'exit 1' is no longer supported.

Signed-off-by: Gianfranco Costamagna <costamagnagianfranco@yahoo.it>
Signed-off-by: Gianfranco Costamagna <gianfranco.costamagna@abinsula.com>
Signed-off-by: Gianfranco Costamagna <locutusofborg@debian.org>