### PR TITLE
qt5-creator: backport commit to fix compile error

### DIFF
--- a/recipes-qt/qt5/qt5-creator/0001-Fix-QPainterPath-related-compilation-errors-in-Qt-5..patch
+++ b/recipes-qt/qt5/qt5-creator/0001-Fix-QPainterPath-related-compilation-errors-in-Qt-5..patch
@@ -1,0 +1,120 @@
+From b8ad0fdae90679b18238f58522058ea9b5934646 Mon Sep 17 00:00:00 2001
+From: Friedemann Kleint <Friedemann.Kleint@qt.io>
+Date: Thu, 12 Mar 2020 09:26:58 +0100
+Subject: [PATCH] Fix QPainterPath-related compilation errors in Qt 5.15
+
+Some include of QPainterPath was removed in Qt, causing errors like:
+
+easingpane\easinggraph.cpp(258): error C2079: 'path' uses undefined class 'QPainterPath'
+easingpane\easinggraph.cpp(275): error C2027: use of undefined type 'QPainterPath'
+easingpane\easinggraph.cpp(305): error C2664: 'void QPainter::drawPath(const QPainterPath &)': cannot convert argument 1 from 'int'
+to 'const QPainterPath &'
+easingpane\easinggraph.cpp(305): note: Reason: cannot convert from 'int' to 'const QPainterPath'
+easingpane\easinggraph.cpp(305): note: use of undefined type 'QPainterPath'
+...
+
+Add the missing include statements.
+
+Change-Id: I4f3383cbcec891a52480a683c9c76ed5deee2b2a
+Reviewed-by: Eike Ziller <eike.ziller@qt.io>
+
+Upstream-Status: Backport
+Signed-off-by: Matthew Zeng <matthew.zeng@windriver.com>
+
+---
+ src/libs/modelinglib/qmt/stereotype/shapepaintvisitor.cpp  | 2 ++
+ src/libs/qmleditorwidgets/easingpane/easingcontextpane.cpp | 1 +
+ src/libs/qmleditorwidgets/easingpane/easinggraph.cpp       | 1 +
+ src/plugins/coreplugin/fancyactionbar.cpp                  | 1 +
+ src/plugins/coreplugin/manhattanstyle.cpp                  | 1 +
+ src/plugins/texteditor/texteditor.cpp                      | 1 +
+ src/plugins/texteditor/texteditoroverlay.cpp               | 1 +
+ 7 files changed, 8 insertions(+)
+
+diff --git a/src/libs/modelinglib/qmt/stereotype/shapepaintvisitor.cpp b/src/libs/modelinglib/qmt/stereotype/shapepaintvisitor.cpp
+index 880835287a..930f8450ad 100644
+--- a/src/libs/modelinglib/qmt/stereotype/shapepaintvisitor.cpp
++++ b/src/libs/modelinglib/qmt/stereotype/shapepaintvisitor.cpp
+@@ -27,6 +27,8 @@
+
+ #include "shapes.h"
+
++#include <QPainterPath>
++
+ namespace qmt {
+
+ ShapePaintVisitor::ShapePaintVisitor(QPainter *painter, const QPointF &scaledOrigin, const QSizeF &originalSize,
+diff --git a/src/libs/qmleditorwidgets/easingpane/easingcontextpane.cpp b/src/libs/qmleditorwidgets/easingpane/easingcontextpane.cpp
+index a794b337a0..d781288557 100644
+--- a/src/libs/qmleditorwidgets/easingpane/easingcontextpane.cpp
++++ b/src/libs/qmleditorwidgets/easingpane/easingcontextpane.cpp
+@@ -30,6 +30,7 @@
+
+ #include <QGraphicsPixmapItem>
+ #include <QGraphicsScene>
++#include <QPainterPath>
+ #include <QPropertyAnimation>
+ #include <QSequentialAnimationGroup>
+
+diff --git a/src/libs/qmleditorwidgets/easingpane/easinggraph.cpp b/src/libs/qmleditorwidgets/easingpane/easinggraph.cpp
+index 4163569c04..e8360e0db6 100644
+--- a/src/libs/qmleditorwidgets/easingpane/easinggraph.cpp
++++ b/src/libs/qmleditorwidgets/easingpane/easinggraph.cpp
+@@ -26,6 +26,7 @@
+ #include "easinggraph.h"
+
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QStyleOptionGraphicsItem>
+ #include <math.h>
+
+diff --git a/src/plugins/coreplugin/fancyactionbar.cpp b/src/plugins/coreplugin/fancyactionbar.cpp
+index 284b68fdae..c4a1f822b1 100644
+--- a/src/plugins/coreplugin/fancyactionbar.cpp
++++ b/src/plugins/coreplugin/fancyactionbar.cpp
+@@ -38,6 +38,7 @@
+ #include <QEvent>
+ #include <QMouseEvent>
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QPixmapCache>
+ #include <QPropertyAnimation>
+ #include <QStyle>
+diff --git a/src/plugins/coreplugin/manhattanstyle.cpp b/src/plugins/coreplugin/manhattanstyle.cpp
+index b55b885615..d1617534d5 100644
+--- a/src/plugins/coreplugin/manhattanstyle.cpp
++++ b/src/plugins/coreplugin/manhattanstyle.cpp
+@@ -43,6 +43,7 @@
+ #include <QLineEdit>
+ #include <QMenuBar>
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QPixmap>
+ #include <QStatusBar>
+ #include <QStyleFactory>
+diff --git a/src/plugins/texteditor/texteditor.cpp b/src/plugins/texteditor/texteditor.cpp
+index 2a6563c219..a38fab49b0 100644
+--- a/src/plugins/texteditor/texteditor.cpp
++++ b/src/plugins/texteditor/texteditor.cpp
+@@ -101,6 +101,7 @@
+ #include <QMessageBox>
+ #include <QMimeData>
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QPrintDialog>
+ #include <QPrinter>
+ #include <QPropertyAnimation>
+diff --git a/src/plugins/texteditor/texteditoroverlay.cpp b/src/plugins/texteditor/texteditoroverlay.cpp
+index 735869082f..b923b257c3 100644
+--- a/src/plugins/texteditor/texteditoroverlay.cpp
++++ b/src/plugins/texteditor/texteditoroverlay.cpp
+@@ -30,6 +30,7 @@
+ #include <QDebug>
+ #include <QMap>
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QTextBlock>
+
+ #include <algorithm>
+--
+2.26.0

--- a/recipes-qt/qt5/qt5-creator_git.bb
+++ b/recipes-qt/qt5/qt5-creator_git.bb
@@ -26,6 +26,7 @@ PV = "4.9.2+git${SRCPV}"
 SRC_URI = " \
     git://code.qt.io/qt-creator/qt-creator.git;branch=4.9 \
     file://0001-clangformat-AllowShortIfStatementsOnASingleLine-is-n.patch \
+    file://0001-Fix-QPainterPath-related-compilation-errors-in-Qt-5..patch \
 "
 SRC_URI_append_libc-musl = " file://0001-Link-with-libexecinfo-on-musl.patch"
 


### PR DESCRIPTION
This fixes compile errors when trying to build qt5-creator.

A snippet of the error is the following:

```
...
../../../../git/src/libs/qmleditorwidgets/easingpane/easinggraph.cpp: In member function 'virtual void EasingGraph::paintEvent(QPaintEvent*)':
../../../../git/src/libs/qmleditorwidgets/easingpane/easinggraph.cpp:258:18: error: aggregate 'QPainterPath path' has incomplete type and cannot be defined
258 |     QPainterPath path;
|                  ^~~~
../../../../git/src/libs/qmleditorwidgets/easingpane/easinggraph.cpp:275:29: error: invalid use of incomplete type 'class QPainterPath'
275 |         path = QPainterPath();
|                             ^
...
```

Signed-off-by: Matthew Zeng <matthew.zeng@windriver.com>