### PR TITLE
qt5-ptest: give rwx permission to user for all the test files

### DIFF
--- a/recipes-qt/qt5/qt5-ptest.inc
+++ b/recipes-qt/qt5/qt5-ptest.inc
@@ -16,7 +16,7 @@ fakeroot do_install_ptest() {
     for var in ` find ${B}/tests/auto/ -name tst_*`; do
         if [ -z ` echo ${var##*/} | grep '\.'` ]; then
             echo ${var##*/} >> ${t}/tst_list
-            install -m 0644  ${var} ${t}
+            install -m 0744  ${var} ${t}
         fi
     done
 }


### PR DESCRIPTION
Otherwise, `ptest-runner qtbase` will fail with numerous Permission Denied errors

Signed-off-by: Mingde (Matthew) Zeng <matthew.zeng@windriver.com>