### PR TITLE
qtbase_git: remove path of the build host from qmake.conf

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -253,9 +253,10 @@ do_install_append() {
     echo "# default compiler options which can be overwritten from the environment" >> $conf
     echo "isEmpty(QMAKE_AR): QMAKE_AR = ${OE_QMAKE_AR} cqs" >> $conf
     echo "isEmpty(QMAKE_CC): QMAKE_CC = $OE_QMAKE_CC_NO_SYSROOT" >> $conf
-    echo "isEmpty(QMAKE_CFLAGS): QMAKE_CFLAGS = ${OE_QMAKE_CFLAGS}" >> $conf
     echo "isEmpty(QMAKE_CXX): QMAKE_CXX = $OE_QMAKE_CXX_NO_SYSROOT" >> $conf
-    echo "isEmpty(QMAKE_CXXFLAGS): QMAKE_CXXFLAGS = ${OE_QMAKE_CXXFLAGS}" >> $conf
+    # OE_QMAKE_CFLAGS and OE_QMAKE_CXXFLAGS contain path of the build host, which is not useful for the target.
+    echo "isEmpty(QMAKE_CFLAGS): QMAKE_CFLAGS = ${OE_QMAKE_CFLAGS}" | sed -e 's/-fdebug-prefix-map=[^ ]*//g' | sed -e 's/-fmacro-prefix-map=[^ ]*//g' >> $conf
+    echo "isEmpty(QMAKE_CXXFLAGS): QMAKE_CXXFLAGS = ${OE_QMAKE_CXXFLAGS}" | sed -e 's/-fdebug-prefix-map=[^ ]*//g' | sed -e 's/-fmacro-prefix-map=[^ ]*//g' >> $conf
     echo "isEmpty(QMAKE_LINK): QMAKE_LINK = $OE_QMAKE_LINK_NO_SYSROOT" >> $conf
     echo "isEmpty(QMAKE_LINK_SHLIB): QMAKE_LINK_SHLIB = $OE_QMAKE_LINK_NO_SYSROOT" >> $conf
     echo "isEmpty(QMAKE_LINK_C): QMAKE_LINK_C = $OE_QMAKE_LINK_NO_SYSROOT" >> $conf


### PR DESCRIPTION
OE_QMAKE_CFLAGS and OE_QMAKE_CXXFLAGS contain path of the build
host, which is not useful for the target, and can be a potential
security risk.

It looks like the following in the target qmake.conf (actual build host path replaced with $PATH_OF_BUILD_HOST):

isEmpty(QMAKE_CFLAGS): QMAKE_CFLAGS =  -O2 -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=$PATH_OF_BUILD_HOST/qtbase/5.15.0+gitAUTOINC+f6fe4bbab7-r0=/usr/src/debug/qtbase/5.15.0+gitAUTOINC+f6fe4bbab7-r0                      -fdebug-prefix-map=$PATH_OF_BUILD_HOST/qtbase/5.15.0+gitAUTOINC+f6fe4bbab7-r0=/usr/src/debug/qtbase/5.15.0+gitAUTOINC+f6fe4bbab7-r0                      -fdebug-prefix-map=$PATH_OF_BUILD_HOST/qtbase/5.15.0+gitAUTOINC+f6fe4bbab7-r0/recipe-sysroot=                      -fdebug-prefix-map=$PATH_OF_BUILD_HOST/qtbase/5.15.0+gitAUTOINC+f6fe4bbab7-r0/recipe-sysroot-native=

-fmacro-prefix-map and -fdebug-prefix-map are therefore removed from
qmake.conf on the target, as these are default options only that can be
overridden any time.

Signed-off-by: Mingde (Matthew) Zeng <matthew.zeng@windriver.com>