### PR TITLE
qt5: Link with -pthread for riscv64

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -172,6 +172,8 @@ QT_CONFIG_FLAGS_GOLD = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', '-
 QT_CONFIG_FLAGS_GOLD = "-no-use-gold-linker"
 LDFLAGS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', ' -fuse-ld=bfd ', '', d)}"
 
+LDFLAGS_append_riscv64 = " -pthread"
+
 QT_CONFIG_FLAGS += " \
     ${QT_CONFIG_FLAGS_GOLD} \
     -shared \

--- a/recipes-qt/qt5/qtdeclarative_git.bb
+++ b/recipes-qt/qt5/qtdeclarative_git.bb
@@ -19,6 +19,8 @@ SRC_URI += " \
     file://0002-Use-python3-explicitly.patch \
 "
 
+LDFLAGS_append_riscv64 = " -pthread"
+
 DEPENDS += "qtbase qtdeclarative-native"
 
 PACKAGECONFIG ??= "qml-debug qml-network ${@bb.utils.contains('DISTRO_FEATURES', 'qt5-static', 'static', '', d)}"


### PR DESCRIPTION
Linking with -pthread fixes the missing atomic linker failures on riscv64.

Thsi fixes the following linker errors:
    qtestcase.h:359: more undefined references to `__atomic_fetch_xor_1' follow
    collect2: error: ld returned 1 exit status

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>