### PR TITLE
qtwebkit: Add patch to fix build with bison 3.7

### DIFF
--- a/recipes-qt/qt5/qtwebkit/0006-Fix-build-with-bison37.patch
+++ b/recipes-qt/qt5/qtwebkit/0006-Fix-build-with-bison37.patch
@@ -1,0 +1,52 @@
+From d92b11fea65364fefa700249bd3340e0cd4c5b31 Mon Sep 17 00:00:00 2001
+From: Dmitry Shachnev <mitya57@gmail.com>
+Date: Tue, 4 Aug 2020 21:04:06 +0300
+Subject: [PATCH] Let Bison generate the header directly, to fix build with
+ Bison 3.7
+
+Starting with Bison 3.7, the generated C++ file #include's the header
+by default, instead of duplicating it. So we should not delete it.
+
+Remove the code to add #ifdef guards to the header, since Bison adds
+them itself since version 2.6.3.
+
+Found at [1]
+
+[1] https://github.com/qtwebkit/qtwebkit/commit/d92b11fea65364fefa700249bd3340e0cd4c5b31
+
+Upstream-Status: Pending
+---
+ Source/WebCore/css/makegrammar.pl | 21 +--------------------
+ 1 file changed, 1 insertion(+), 20 deletions(-)
+
+diff --git a/Source/WebCore/css/makegrammar.pl b/Source/WebCore/css/makegrammar.pl
+index 5d63b08102eb..9435701c7061 100644
+--- a/Source/WebCore/css/makegrammar.pl
++++ b/Source/WebCore/css/makegrammar.pl
+@@ -73,25 +73,6 @@
+ }
+ 
+ my $fileBase = File::Spec->join($outputDir, $filename);
+-my @bisonCommand = ($bison, "-d", "-p", $symbolsPrefix, $grammarFilePath, "-o", "$fileBase.cpp");
++my @bisonCommand = ($bison, "--defines=$fileBase.h", "-p", $symbolsPrefix, $grammarFilePath, "-o", "$fileBase.cpp");
+ push @bisonCommand, "--no-lines" if $^O eq "MSWin32"; # Work around bug in bison >= 3.0 on Windows where it puts backslashes into #line directives.
+ system(@bisonCommand) == 0 or die;
+-
+-open HEADER, ">$fileBase.h" or die;
+-print HEADER << "EOF";
+-#ifndef CSSGRAMMAR_H
+-#define CSSGRAMMAR_H
+-EOF
+-
+-open HPP, "<$fileBase.cpp.h" or open HPP, "<$fileBase.hpp" or die;
+-while (<HPP>) {
+-    print HEADER;
+-}
+-close HPP;
+-
+-print HEADER "#endif\n";
+-close HEADER;
+-
+-unlink("$fileBase.cpp.h");
+-unlink("$fileBase.hpp");
+-

--- a/recipes-qt/qt5/qtwebkit_git.bb
+++ b/recipes-qt/qt5/qtwebkit_git.bb
@@ -16,6 +16,7 @@ SRC_URI += "\
     file://0003-Fix-build-with-non-glibc-libc-on-musl.patch \
     file://0004-Fix-build-bug-for-armv32-BE.patch \
     file://0005-PlatformQt.cmake-Do-not-generate-hardcoded-include-p.patch \
+    file://0006-Fix-build-with-bison37.patch \
 "
 
 inherit cmake_qt5 perlnative


### PR DESCRIPTION
Fixes:
|... /build/DerivedSources/WebCore/XPathGrammar.cpp:120:10: fatal error: XPathGrammar.hpp: No such file or directory
|   120 | #include "XPathGrammar.hpp"
|       |          ^~~~~~~~~~~~~~~~~~
| ...
| .../build/DerivedSources/WebCore/CSSGrammar.cpp:160:10: fatal error: CSSGrammar.hpp: No such file or directory
|   160 | #include "CSSGrammar.hpp"
|       |          ^~~~~~~~~~~~~~~~

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>