### PR TITLE
python3-pyqt5: Update to dev2008271829 snapshot

### DIFF
--- a/recipes-python/pyqt5/python3-pyqt5_5.15.1.dev2008271829.bb
+++ b/recipes-python/pyqt5/python3-pyqt5_5.15.1.dev2008271829.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "\
 SRC_URI = "\
     https://www.riverbankcomputing.com/static/Downloads/PyQt5/PyQt5-${PV}.tar.gz \
 "
-SRC_URI[sha256sum] = "6c83e0e82e3f2e65079c7442bd15f09b132ea482bb66ef6c1ece5ca43d97f839"
+SRC_URI[sha256sum] = "c677f538eb52140d454b158f8916f9949737c6a31397606ddf91f4aa569f6cc4"
 
 S = "${WORKDIR}/PyQt5-${PV}"
 


### PR DESCRIPTION
Old version no longer available:

ERROR: python3-pyqt5-5.15.1.dev2008081558-r0 do_fetch: Fetcher failure
for URL: 'https://www.riverbankcomputing.com/static/Downloads/PyQt5/PyQt5-5.15.1.dev2008081558.tar.gz'.
Unable to fetch URL from any source.

Signed-off-by: Daniel Gomez <daniel@qtec.com>