### PR TITLE
pyqtchart: Update to version 5.15.1 and use pypi

### DIFF
--- a/recipes-python/pyqtchart/python3-pyqtchart_5.15.1.bb
+++ b/recipes-python/pyqtchart/python3-pyqtchart_5.15.1.bb
@@ -1,15 +1,18 @@
 SUMMARY = "Python Qt Chart Bindings"
 AUTHOR = "Adrian.Fiergolski@fastree3d.com"
+HOMEPAGE = "https://www.riverbankcomputing.com/software/pyqtchart"
 SECTION = "devel/python"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "\
     file://LICENSE;md5=d32239bcb673463ab874e80d47fae504 \
 "
-SRC_URI = "\
-    https://www.riverbankcomputing.com/static/Downloads/PyQtChart/${PV}/PyQtChart-${PV}.tar.gz \
-"
-SRC_URI[md5sum] = "d5d37bff46b690d6318e5e5f25dd5213"
-SRC_URI[sha256sum] = "49960a1483527857b38c1527f9b6328d30bdcc84521f579c0a561a892f54130e"
+
+inherit pypi
+
+PYPI_PACKAGE = "PyQtChart"
+
+SRC_URI[md5sum] = "8a36bc796b0d9a2301e613c382336b0e"
+SRC_URI[sha256sum] = "8d976b3dbfb233fb0123129323c68adb9d3693c945bba1e227e004208f0747bc"
 
 S = "${WORKDIR}/PyQtChart-${PV}"
 


### PR DESCRIPTION
Old version no longer available through riverbankcomputing.com.
Update to 5.15.1 and download the package sources using pypi class.