### PR TITLE
python3-pyqt: add native support

### DIFF
--- a/recipes-qt/qt5/qtquickcontrols2_git.bb
+++ b/recipes-qt/qt5/qtquickcontrols2_git.bb
@@ -11,3 +11,7 @@ LIC_FILES_CHKSUM = " \
 DEPENDS += "qtdeclarative qtdeclarative-native"
 
 SRCREV = "16f27dfa3588c2bf377568ce00bf534af48c9558"
+
+RPROVIDES_class-native += "qtquickcontrols2-mkspecs-native"
+
+BBCLASSEXTEND += "native nativesdk"


### PR DESCRIPTION
PYQT_MODULES for native is customized to build just QtCore module,
since the point of native builds is to get the pyqt5 build tools,
not to run gui applications.

The custom configure block can be shared between target
and native if you just configure the sysroot option accordingly
and use STAGING_INCDIR to locate the python headers to build
against.

The custom install block has to be called separately from
target and native install function, thanks to qmake5 bbclass having
a native-specific override for do_install().

Also added a 'sed' into the install which cleans up hard-coded
paths in generated wrapper scripts.

Signed-off-by: S. Lockwood-Childs <sjl@vctlabs.com>