### PR TITLE
qt5-native.inc, nativesdk-qt5.inc, nativesdk-packagegroup-qt5-toolcha…

### DIFF
--- a/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
+++ b/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
@@ -3,7 +3,7 @@
 SUMMARY = "Host packages for the Qt5 standalone SDK or external toolchain"
 LICENSE = "MIT"
 
-inherit nativesdk packagegroup
+inherit packagegroup nativesdk
 
 PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"
 

--- a/recipes-qt/qt5/nativesdk-qt5.inc
+++ b/recipes-qt/qt5/nativesdk-qt5.inc
@@ -1,4 +1,4 @@
-inherit nativesdk qmake5_base
+inherit qmake5_base nativesdk
 
 # we don't want conflicts with qt4
 OE_QMAKE_PATH_HEADERS = "${OE_QMAKE_PATH_QT_HEADERS}"

--- a/recipes-qt/qt5/qt5-native.inc
+++ b/recipes-qt/qt5/qt5-native.inc
@@ -1,4 +1,4 @@
-inherit native qmake5_base
+inherit qmake5_base native
 
 # we don't want conflicts with qt4
 OE_QMAKE_PATH_HEADERS = "${OE_QMAKE_PATH_QT_HEADERS}"


### PR DESCRIPTION
…in-host: reorder inherits to fix new QA check

* fixes:
WARNING: meta-qt5/recipes-qt/qt5/qtbase-native_git.bb: QA Issue: qtbase-native: native/nativesdk class is not inherited last, this can result in unexpected behaviour.  [native-last]
WARNING: meta-qt5/recipes-qt/qt5/nativesdk-qtbase_git.bb: QA Issue: nativesdk-qtbase: native/nativesdk class is not inherited last, this can result in unexpected behaviour.  [native-last]
WARNING: meta-qt5/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb: QA Issue: nativesdk-packagegroup-qt5-toolchain-host: native/nativesdk class is not inherited last, this can result in unexpected behaviour.  [native-last]

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>