### PR TITLE
qtdeclarative: fix buildtime configuration

### DIFF
--- a/recipes-qt/qt5/qtdeclarative_git.bb
+++ b/recipes-qt/qt5/qtdeclarative_git.bb
@@ -27,6 +27,8 @@ PACKAGECONFIG[qml-debug] = "-qml-debug,-no-qml-debug"
 PACKAGECONFIG[qml-network] = "-qml-network, -no-qml-network"
 PACKAGECONFIG[static] = ",,qtdeclarative-native"
 
+EXTRA_QMAKEVARS_CONFIGURE += "${PACKAGECONFIG_CONFARGS}"
+
 do_install_ptest() {
     mkdir -p ${D}${PTEST_PATH}
     for var in `find ${B}/tests/auto/ -name tst_*`; do


### PR DESCRIPTION
Without this line `PACKAGECONFIG` did not have any influence on the actual package
configuration.