### PR TITLE
qt5-creator: Fix parse with latest meta-clang

### DIFF
--- a/recipes-qt/qt5/qt5-creator_git.bb
+++ b/recipes-qt/qt5/qt5-creator_git.bb
@@ -41,7 +41,7 @@ PACKAGECONFIG_append_toolchain-clang = " clang"
 
 # Important note: In case clang was added to qttools' PACKAGECONFIG, it has to
 # be added here too - otherwise build fails trying to link native clang libraries
-PACKAGECONFIG[clang] = ",,clang llvm-common"
+PACKAGECONFIG[clang] = ",,clang"
 
 COMPATIBLE_HOST_toolchain-clang_riscv32 = "null"
 COMPATIBLE_HOST_toolchain-clang_riscv64 = "null"


### PR DESCRIPTION
Since meta-clang's
commit d38888ea80965206c1d2eab9958db1ff980c56c4
Author: Zoltán Böszörményi <zboszor@pr.hu>
Date:   Thu Feb 18 04:29:49 2021 -0500

    clang: Merge llvm-common into clang

    Signed-off-by: Zoltán Böszörményi <zboszor@pr.hu>

parsing fails with:
| ERROR: Nothing PROVIDES 'llvm-common' (but /home/superandy/data/oe-core/sources/meta-qt5/recipes-qt/qt5/qt5-creator_git.bb DEPENDS on or otherwise requires it

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>