### PR TITLE
qtwebkit: Disable gold linker for riscv/ppc/mips

### DIFF
--- a/recipes-qt/qt5/qt3d/0001-renderers-opengl-Link-in-libatomic-on-riscv.patch
+++ b/recipes-qt/qt5/qt3d/0001-renderers-opengl-Link-in-libatomic-on-riscv.patch
@@ -1,0 +1,28 @@
+From b2c6dd0330d9dee417192a32ae6c636b77b6bf46 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 8 Mar 2021 15:16:01 -0800
+Subject: [PATCH] renderers/opengl: Link in libatomic on riscv
+
+GCC 11 needs this since it failing to find a builtin function
+
+Fixes
+src/plugins/renderers/opengl/renderer/renderview.cpp:107: undefined reference to `__atomic_exchange_1'
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/plugins/renderers/opengl/opengl.pri | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/plugins/renderers/opengl/opengl.pri b/src/plugins/renderers/opengl/opengl.pri
+index 1682ab7b3..31b71dd6b 100644
+--- a/src/plugins/renderers/opengl/opengl.pri
++++ b/src/plugins/renderers/opengl/opengl.pri
+@@ -39,3 +39,5 @@ qtConfig(qt3d-simd-sse2):!qtConfig(qt3d-simd-avx2) {
+     CONFIG += simd
+     QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_SSE2
+ }
++
++LIBS += "-latomic"
+-- 
+2.30.1
+

--- a/recipes-qt/qt5/qt3d_git.bb
+++ b/recipes-qt/qt5/qt3d_git.bb
@@ -16,6 +16,8 @@ DEPENDS_class-target += "qtdeclarative qt3d-native"
 SRC_URI += " \
     file://0001-Allow-a-tools-only-build.patch \
 "
+SRC_URI_append_riscv64 = " file://0001-renderers-opengl-Link-in-libatomic-on-riscv.patch"
+SRC_URI_append_riscv32 = " file://0001-renderers-opengl-Link-in-libatomic-on-riscv.patch"
 
 PACKAGECONFIG ??= ""
 PACKAGECONFIG_class-native ??= "tools-only"

--- a/recipes-qt/qt5/qtquickcontrols2_git.bb
+++ b/recipes-qt/qt5/qtquickcontrols2_git.bb
@@ -12,6 +12,4 @@ DEPENDS += "qtdeclarative qtdeclarative-native"
 
 SRCREV = "16f27dfa3588c2bf377568ce00bf534af48c9558"
 
-RPROVIDES_class-native += "qtquickcontrols2-mkspecs-native"
-
 BBCLASSEXTEND += "native nativesdk"

--- a/recipes-qt/qt5/qtquickcontrols2_git.bb
+++ b/recipes-qt/qt5/qtquickcontrols2_git.bb
@@ -11,3 +11,7 @@ LIC_FILES_CHKSUM = " \
 DEPENDS += "qtdeclarative qtdeclarative-native"
 
 SRCREV = "16f27dfa3588c2bf377568ce00bf534af48c9558"
+
+RPROVIDES_class-native += "qtquickcontrols2-mkspecs-native"
+
+BBCLASSEXTEND += "native nativesdk"

--- a/recipes-qt/qt5/qtwebkit/0010-webdriver-libatomic.patch
+++ b/recipes-qt/qt5/qtwebkit/0010-webdriver-libatomic.patch
@@ -1,0 +1,23 @@
+link with libatomic
+
+This fixes build with C11
+
+lib/../Source/WTF/wtf/CMakeFiles/WTF.dir/Assertions.cpp.o:/usr/include/c++/11.0.1/bits/atomic_base.h:520: more undefined references to `__atomic_compare_exchange_1' follow
+| collect2: error: ld returned 1 exit status
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+--- a/Source/WTF/wtf/CMakeLists.txt
++++ b/Source/WTF/wtf/CMakeLists.txt
+@@ -245,6 +245,10 @@ if (NOT USE_SYSTEM_MALLOC)
+     list(APPEND WTF_LIBRARIES bmalloc)
+ endif ()
+ 
++list(APPEND WTF_LIBRARIES
++     -Wl,--as-needed -Wl,-latomic -Wl,--no-as-needed
++)
++
+ list(APPEND WTF_SOURCES
+     unicode/icu/CollatorICU.cpp
+ )

--- a/recipes-qt/qt5/qtwebkit_git.bb
+++ b/recipes-qt/qt5/qtwebkit_git.bb
@@ -23,6 +23,9 @@ SRC_URI += "\
     file://0009-Riscv-Add-support-for-riscv.patch \
 "
 
+SRC_URI_append_riscv32 = " file://0010-webdriver-libatomic.patch "
+SRC_URI_append_riscv64 = " file://0010-webdriver-libatomic.patch "
+
 inherit cmake_qt5 perlnative
 
 inherit python3native

--- a/recipes-qt/qt5/qtwebkit_git.bb
+++ b/recipes-qt/qt5/qtwebkit_git.bb
@@ -66,8 +66,9 @@ EXTRA_OECMAKE_append_riscv64 = " -DENABLE_JIT=OFF -DENABLE_C_LOOP=ON "
 # Disable gold on mips64/clang
 # mips64-yoe-linux-musl-ld.gold: internal error in get_got_page_offset, at ../../gold/mips.cc:6260
 # mips-yoe-linux-musl-ld.gold: error: Can't find matching LO16 reloc
-EXTRA_OECMAKE_append_toolchain-clang_mipsarch = " -DUSE_LD_GOLD=OFF "
-EXTRA_OECMAKE_append_toolchain-clang_riscv64 = " -DUSE_LD_GOLD=OFF "
+EXTRA_OECMAKE_append_mipsarch = " -DUSE_LD_GOLD=OFF "
+EXTRA_OECMAKE_append_powerpc = " -DUSE_LD_GOLD=OFF "
+EXTRA_OECMAKE_append_riscv64 = " -DUSE_LD_GOLD=OFF "
 
 PACKAGECONFIG ??= "qtlocation qtmultimedia qtsensors qtwebchannel \
     ${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)} \


### PR DESCRIPTION
gold linker seems to not link the shared lib properly as it results in
textrels on these arches. So fallback to bfd linker.

Signed-off-by: Khem Raj <raj.khem@gmail.com>