### PR TITLE
cmake_qt5: Set qtbase DEPENDS target agnostic

### DIFF
--- a/classes/cmake_qt5.bbclass
+++ b/classes/cmake_qt5.bbclass
@@ -1,7 +1,9 @@
 inherit cmake
 inherit qmake5_paths
 
-DEPENDS_prepend = "qtbase qtbase-native "
+DEPENDS_prepend = "qtbase-native "
+DEPENDS_prepend_class-nativesdk = "nativesdk-qtbase "
+DEPENDS_prepend_class-target = "qtbase "
 
 EXTRA_OECMAKE_prepend = " \
     -DOE_QMAKE_PATH_PREFIX=${OE_QMAKE_PATH_PREFIX} \


### PR DESCRIPTION
Discussion started at [1]

To start a proper fix, set qtbase dependencies depending on target.

[1] https://github.com/Freescale/meta-freescale/issues/798

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>