### PR TITLE
qtwebengine: Add missing dbus dependency

### DIFF
--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -12,6 +12,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 DEPENDS += " \
+    dbus \
     libpng-native \
     nss-native \
     nspr-native \


### PR DESCRIPTION
QtWebEngine has a hard dependency on D-Bus, which is currently fulfilled indirectly via the pulseaudio dependency.
As soon as pulseaudio is disabled via DISTRO_FEATURES_BACKFILL_CONSIDERED, building QtWebEngine fails.
Add a direct dbus dependency to qtwebengine_git.bb to fix this.