### PR TITLE
layer.conf: set LAYERSERIES_COMPAT with honister

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_qt5-layer = "1"
 
 LAYERDEPENDS_qt5-layer = "core"
 
-LAYERSERIES_COMPAT_qt5-layer = "dunfell gatesgarth hardknott"
+LAYERSERIES_COMPAT_qt5-layer = "honister"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 


### PR DESCRIPTION
Set LAYERSERIES_COMPAT with honister and remove old codenames.

Signed-off-by: Kai Kang <kai.kang@windriver.com>