### PR TITLE
qtsvg: fix CVE-2021-3481

### DIFF
--- a/recipes-qt/qt5/qtsvg/CVE-2021-3481.patch
+++ b/recipes-qt/qt5/qtsvg/CVE-2021-3481.patch
@@ -1,0 +1,73 @@
+CVE: CVE-2021-3481
+Upstream-Status: Backport [https://codereview.qt-project.org/gitweb?p=qt%2Fqtsvg.git;a=commit;h=bfd6ee0]
+
+Backport and squash commits 85b70a721695991e8a5bbe4aa52e5320e170e90c and
+bfd6ee0d8cf34b63d32adf10ed93daa0086b359f to fix CVE-2021-3481.
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+
+From 6c40fd492eafabe67177c0e84839beec5be298b8 Mon Sep 17 00:00:00 2001
+From: Eirik Aavitsland <eirik.aavitsland@qt.io>
+Date: Tue, 1 Dec 2020 14:39:59 +0100
+Subject: [PATCH] Improve handling of malformed numeric values in svg files
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Catch cases where the input is not containable in a qreal, and avoid
+passing on inf values.
+
+Pick-to: 6.0 5.15 5.12
+Change-Id: I1ab8932d94473916815385240c29e03afb0e0c9e
+Reviewed-by: Robert Loehning <robert.loehning@qt.io>
+Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>
+
+Clamp parsed doubles to float representable values
+
+Parts of our rendering assumes incoming doubles can still be sane
+floats.
+
+Pick-to: 6.1 6.0 5.15 5.12
+Fixes: QTBUG-91507
+Change-Id: I7086a121e1b5ed47695a1251ea90e774dd8f148d
+Reviewed-by: Robert Löhning <robert.loehning@qt.io>
+Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>
+Reviewed-by: Mårten Nordheim <marten.nordheim@qt.io>
+---
+ src/svg/qsvghandler.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/svg/qsvghandler.cpp b/src/svg/qsvghandler.cpp
+index c937254..9dac05c 100644
+--- a/src/svg/qsvghandler.cpp
++++ b/src/svg/qsvghandler.cpp
+@@ -65,6 +65,7 @@
+ #include "private/qmath_p.h"
+ 
+ #include "float.h"
++#include <cmath>
+ 
+ QT_BEGIN_NAMESPACE
+ 
+@@ -672,6 +673,9 @@ static qreal toDouble(const QChar *&str)
+             val = -val;
+     } else {
+         val = QByteArray::fromRawData(temp, pos).toDouble();
++        // Do not tolerate values too wild to be represented normally by floats
++        if (qFpClassify(float(val)) != FP_NORMAL)
++            val = 0;
+     }
+     return val;
+ 
+@@ -3043,6 +3047,8 @@ static QSvgStyleProperty *createRadialGradientNode(QSvgNode *node,
+         ncy = toDouble(cy);
+     if (!r.isEmpty())
+         nr = toDouble(r);
++    if (nr < 0.5)
++        nr = 0.5;
+ 
+     qreal nfx = ncx;
+     if (!fx.isEmpty())
+-- 
+2.29.2
+

--- a/recipes-qt/qt5/qtsvg_git.bb
+++ b/recipes-qt/qt5/qtsvg_git.bb
@@ -12,4 +12,6 @@ LIC_FILES_CHKSUM = " \
 
 DEPENDS += "qtbase"
 
+SRC_URI_append = " file://CVE-2021-3481.patch"
+
 SRCREV = "52d3788c7b0116ea3db232dccca5f1e3f1e229ac"


### PR DESCRIPTION
Backport and squash commits 85b70a721695991e8a5bbe4aa52e5320e170e90c and
bfd6ee0d8cf34b63d32adf10ed93daa0086b359f from qtsvg upstream to fix
CVE-2021-3481.

Ref:
https://security-tracker.debian.org/tracker/CVE-2021-3481

Signed-off-by: Kai Kang <kai.kang@windriver.com>