### PR TITLE
qtbase: add virtual/egl build dependency for eglfs

### DIFF
--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -47,7 +47,7 @@ EXTRA_QMAKEVARS_PRE += "CONFIG+=force_debug_info"
 # http://errors.yoctoproject.org/Errors/Details/150333/
 SECURITY_STRINGFORMAT = ""
 
-# To use system ffmpeg you need to enable also libwebp, opus, vpx
+# To use system ffmpeg you need to enable also libwebp, opus, libvpx
 # Only depenedencies available in oe-core are enabled by default
 PACKAGECONFIG ??= "libevent libpng \
                    ${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio', '', d)}"


### PR DESCRIPTION
The eglfs feature requires the egl feature enabled, otherwise
qtbase:do_configure fails with:

    ERROR: Feature 'eglfs' was enabled, but the pre-condition '!config.android && !config.darwin && !config.win32 && !config.wasm && features.egl' failed.

Signed-off-by: Vivien Didelot <vdidelot@pbsc.com>