### PR TITLE
libconnman-qt5: Fix new repo and update 1.2.34 -> 1.2.35

### DIFF
--- a/recipes-connectivity/libconnman-qt/libconnman-qt5_git.bb
+++ b/recipes-connectivity/libconnman-qt/libconnman-qt5_git.bb
@@ -1,14 +1,14 @@
 require recipes-qt/qt5/qt5.inc
 
 SUMMARY = "Qt Library for ConnMan"
-HOMEPAGE = "https://git.merproject.org/mer-core/libconnman-qt"
+HOMEPAGE = "https://github.com/sailfishos/libconnman-qt"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://libconnman-qt/clockmodel.h;endline=8;md5=ea9f724050803f15d2d900ce3c5dac88"
 DEPENDS += "qtbase qtdeclarative"
-PV = "1.2.34+git${SRCPV}"
+PV = "1.2.35+git${SRCPV}"
 
-SRCREV = "a0b6b0d9a63f28ab41747892f415c89866d62e4a"
-SRC_URI = "git://git.merproject.org/mer-core/libconnman-qt.git;protocol=https \
+SRCREV = "347f20fe1a03bf0624f55b9108c797611e79f7d2"
+SRC_URI = "git://github.com/sailfishos/libconnman-qt.git;protocol=https \
     file://0001-Don-t-use-MeeGo-as-prefix-in-order-to-make-this-a-co.patch \
     file://0001-Add-missing-declarations-for-operator-overloads.patch \
 "

--- a/recipes-connectivity/libqofono/libqofono/0001-also-emit-modemRemoved-and-modemAdded.patch
+++ b/recipes-connectivity/libqofono/libqofono/0001-also-emit-modemRemoved-and-modemAdded.patch
@@ -1,4 +1,4 @@
-From 05241dc61e8c43a12f91ee9976a2ecb2337a3eaf Mon Sep 17 00:00:00 2001
+From d2ceb83fe889d7cb40ad1e0d71e75d726a87fb28 Mon Sep 17 00:00:00 2001
 From: Christophe Chapuis <chris.chapuis@gmail.com>
 Date: Sat, 13 Jul 2019 11:17:08 +0000
 Subject: [PATCH] onGetModemsFinished: also emit modemRemoved and modemAdded
@@ -7,17 +7,18 @@ VoiceCall only subscribes to these events, so we need to emit these
 more "atomic" events too.
 
 Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+
 ---
  src/qofonomanager.cpp | 21 ++++++++++++++++++---
  1 file changed, 18 insertions(+), 3 deletions(-)
 
 diff --git a/src/qofonomanager.cpp b/src/qofonomanager.cpp
-index deeb946..e94a3c7 100644
+index e1da658..38cf0e4 100644
 --- a/src/qofonomanager.cpp
 +++ b/src/qofonomanager.cpp
-@@ -40,15 +40,30 @@ void QOfonoManager::Private::handleGetModemsReply(QOfonoManager* obj, ObjectPath
+@@ -88,15 +88,30 @@ void QOfonoManager::Private::handleGetModemsReply(QOfonoManager *obj, ObjectPath
  {
-     bool wasAvailable = available;
+     const bool wasAvailable = available;
      QString prevDefault = defaultModem();
 -    QStringList newModems;
 +    QStringList newModems, oldModems;
@@ -49,6 +50,3 @@ index deeb946..e94a3c7 100644
          Q_EMIT obj->modemsChanged(modems);
      }
      QString newDefault = defaultModem();
--- 
-2.23.0
-

--- a/recipes-connectivity/libqofono/libqofono_git.bb
+++ b/recipes-connectivity/libqofono/libqofono_git.bb
@@ -5,13 +5,14 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 DEPENDS += "qtbase qtdeclarative qtxmlpatterns"
 
-SRCREV = "4eec0c726844b8293eeab7312c96956a77d40e90"
-SRC_URI = "git://git.merproject.org/mer-core/libqofono.git \
+SRCREV = "047b667f18ca73cb7f884f174d1d164a616d6814"
+
+SRC_URI = "git://github.com/sailfishos/libqofono.git;protocol=https \
            file://0001-also-emit-modemRemoved-and-modemAdded.patch \
 "
 S = "${WORKDIR}/git"
 
-PV = "0.100+gitr${SRCPV}"
+PV = "0.103+gitr${SRCPV}"
 
 inherit qmake5
 

--- a/recipes-connectivity/libqofono/libqofonoext_git.bb
+++ b/recipes-connectivity/libqofono/libqofonoext_git.bb
@@ -5,11 +5,11 @@ LIC_FILES_CHKSUM = "file://src/qofonoext.cpp;;beginline=1;endline=14;md5=e78738e
 
 DEPENDS += "qtbase qtdeclarative qtxmlpatterns libqofono"
 
-SRCREV = "bd0999247f3c6446463f83b1f86c3de39c1a5425"
-SRC_URI = "git://git.sailfishos.org/mer-core/libqofonoext.git;protocol=https;"
+SRCREV = "ebe45e0fe46578c24e9fe241e84cd5ca0f097372"
+SRC_URI = "git://github.com/sailfishos/libqofonoext.git;protocol=https"
 S = "${WORKDIR}/git"
 
-PV = "1.025+gitr${SRCPV}"
+PV = "1.027+gitr${SRCPV}"
 
 inherit pkgconfig qmake5
 


### PR DESCRIPTION
libconnman-qt5 repository has been moved to the Sailfish OS GitHub group
as part of the migration of Mer and Sailfish to Sailfish OS domain. More
details here:
https://forum.sailfishos.org/t/changes-needed-to-merge-the-project-names-to-sailfish-os/1672

Update recipe to 1.2.35 release.

Signed-off-by: Daniel Gomez <daniel@qtec.com>