### PR TITLE
Update obsolete git urls.

### DIFF
--- a/recipes-connectivity/libconnman-qt/libconnman-qt5_git.bb
+++ b/recipes-connectivity/libconnman-qt/libconnman-qt5_git.bb
@@ -1,14 +1,14 @@
 require recipes-qt/qt5/qt5.inc
 
 SUMMARY = "Qt Library for ConnMan"
-HOMEPAGE = "https://git.merproject.org/mer-core/libconnman-qt"
+HOMEPAGE = "https://github.com/sailfishos/libconnman-qt"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://libconnman-qt/clockmodel.h;endline=8;md5=ea9f724050803f15d2d900ce3c5dac88"
 DEPENDS += "qtbase qtdeclarative"
 PV = "1.2.34+git${SRCPV}"
 
 SRCREV = "a0b6b0d9a63f28ab41747892f415c89866d62e4a"
-SRC_URI = "git://git.merproject.org/mer-core/libconnman-qt.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/libconnman-qt.git;protocol=https \
     file://0001-Don-t-use-MeeGo-as-prefix-in-order-to-make-this-a-co.patch \
     file://0001-Add-missing-declarations-for-operator-overloads.patch \
 "

--- a/recipes-connectivity/libqofono/libqofono_git.bb
+++ b/recipes-connectivity/libqofono/libqofono_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 DEPENDS += "qtbase qtdeclarative qtxmlpatterns"
 
 SRCREV = "4eec0c726844b8293eeab7312c96956a77d40e90"
-SRC_URI = "git://git.merproject.org/mer-core/libqofono.git \
+SRC_URI = "git://github.com/sailfishos/libqofono.git \
            file://0001-also-emit-modemRemoved-and-modemAdded.patch \
 "
 S = "${WORKDIR}/git"

--- a/recipes-connectivity/libqofono/libqofonoext_git.bb
+++ b/recipes-connectivity/libqofono/libqofonoext_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://src/qofonoext.cpp;;beginline=1;endline=14;md5=e78738e
 DEPENDS += "qtbase qtdeclarative qtxmlpatterns libqofono"
 
 SRCREV = "bd0999247f3c6446463f83b1f86c3de39c1a5425"
-SRC_URI = "git://git.sailfishos.org/mer-core/libqofonoext.git;protocol=https;"
+SRC_URI = "git://github.com/sailfishos/libqofonoext.git;protocol=https;"
 S = "${WORKDIR}/git"
 
 PV = "1.025+gitr${SRCPV}"


### PR DESCRIPTION
Change from git.merproject.org to github.com/sailfishos where needed.

Signed-off-by: Ed Beroset <beroset@ieee.org>