### PR TITLE
qtbase: Fix timezone DST calculation

### DIFF
--- a/recipes-qt/qt5/qtbase-native_git.bb
+++ b/recipes-qt/qt5/qtbase-native_git.bb
@@ -39,6 +39,7 @@ SRC_URI += "\
     file://0019-Define-__NR_futex-if-it-does-not-exist.patch \
     file://0020-Revert-Fix-workaround-in-pthread-destructor.patch \
     file://0021-qfloat16-Include-limits-header.patch \
+    file://0022-fix_timezone_dst.patch \
 "
 
 # common for qtbase-native and nativesdk-qtbase

--- a/recipes-qt/qt5/qtbase/0022-fix_timezone_dst.patch
+++ b/recipes-qt/qt5/qtbase/0022-fix_timezone_dst.patch
@@ -1,0 +1,78 @@
+From: Dilshod Mukhtarov <dilshodm@gmail.com>
+Date: Tue, 2 Nov 2021 22:57:47 +0400
+Subject: [PATCH] fix incorrect dst dates bug (backport from Qt 6.2)
+
+In Qt 5.15.2 the DST is incorrectly calculated using Yocto's tzdata
+(example America/Los_Angeles).
+For example in year 2021 DST has to end at Nov 7, 2021, with this bug it shows Nov 1, 2021.
+
+Signed-off-by: Dilshod Mukhtarov <dilshodm@gmail.com>
+
+diff -Nru a/src/corelib/time/qtimezoneprivate_tz.cpp b/src/corelib/time/qtimezoneprivate_tz.cpp
+--- a/src/corelib/time/qtimezoneprivate_tz.cpp	2020-10-27 12:02:10.000000000 +0400
++++ b/src/corelib/time/qtimezoneprivate_tz.cpp	2021-11-02 22:03:48.529270348 +0400
+@@ -350,6 +350,11 @@
+
+ static QDate calculateDowDate(int year, int month, int dayOfWeek, int week)
+ {
++    if (dayOfWeek == 0) // Sunday; we represent it as 7, POSIX uses 0
++        dayOfWeek = 7;
++    else if (dayOfWeek & ~7 || month < 1 || month > 12 || week < 1 || week > 5)
++        return QDate();
++
+     QDate date(year, month, 1);
+     int startDow = date.dayOfWeek();
+     if (startDow <= dayOfWeek)
+@@ -364,28 +369,37 @@
+
+ static QDate calculatePosixDate(const QByteArray &dateRule, int year)
+ {
++    bool ok;
+     // Can start with M, J, or a digit
+     if (dateRule.at(0) == 'M') {
+         // nth week in month format "Mmonth.week.dow"
+         QList<QByteArray> dateParts = dateRule.split('.');
+-        int month = dateParts.at(0).mid(1).toInt();
+-        int week = dateParts.at(1).toInt();
+-        int dow = dateParts.at(2).toInt();
+-        if (dow == 0)
+-            ++dow;
+-        return calculateDowDate(year, month, dow, week);
++        if (dateParts.count() > 2) {
++            int month = dateParts.at(0).mid(1).toInt(&ok);
++            int week = ok ? dateParts.at(1).toInt(&ok) : 0;
++            int dow = ok ? dateParts.at(2).toInt(&ok) : 0;
++            if (ok)
++                return calculateDowDate(year, month, dow, week);
++        }
+     } else if (dateRule.at(0) == 'J') {
+-        // Day of Year ignores Feb 29
+-        int doy = dateRule.mid(1).toInt();
+-        QDate date = QDate(year, 1, 1).addDays(doy - 1);
+-        if (QDate::isLeapYear(date.year()))
+-            date = date.addDays(-1);
+-        return date;
++        // Day of Year 1...365, ignores Feb 29.
++        // So March always starts on day 60.
++        int doy = dateRule.mid(1).toInt(&ok);
++        if (ok && doy > 0 && doy < 366) {
++            // Subtract 1 because we're adding days *after* the first of
++            // January, unless it's after February in a leap year, when the leap
++            // day cancels that out:
++            if (!QDate::isLeapYear(year) || doy < 60)
++                --doy;
++            return QDate(year, 1, 1).addDays(doy);
++        }
+     } else {
+-        // Day of Year includes Feb 29
+-        int doy = dateRule.toInt();
+-        return QDate(year, 1, 1).addDays(doy - 1);
++        // Day of Year 0...365, includes Feb 29
++        int doy = dateRule.toInt(&ok);
++        if (ok && doy >= 0 && doy < 366)
++            return QDate(year, 1, 1).addDays(doy);
+     }
++    return QDate();
+ }
+
+ // returns the time in seconds, INT_MIN if we failed to parse

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -35,6 +35,7 @@ SRC_URI += "\
     file://0019-Define-__NR_futex-if-it-does-not-exist.patch \
     file://0020-Revert-Fix-workaround-in-pthread-destructor.patch \
     file://0021-qfloat16-Include-limits-header.patch \
+    file://0022-fix_timezone_dst.patch \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with


### PR DESCRIPTION
In Qt5 DST calculation for timezone info generated in yocto is broken. Fix is backported from Qt 6.2.
For example, for America/Los_Angeles 
for Nov 1, 2021 it's already showing winter time, while in reality winter time starts on Nov 7, 2021.
In desktop generated time zone info is a little bit different, so this bug is not hit on desktop.
Here there is a test project and two timezone files for LA included: one is taken from Mint distro and another is from yocto.
[dt-test.zip](https://github.com/meta-qt5/meta-qt5/files/7493948/dt-test.zip)

Output with normal Qt5 (bug) which is affected with yocto TZ where Nov 1 is already in winter time:
```bash
$ ./dt America/Los_Angeles.yocto
QDateTime(2021-10-31 05:00:00.000 PDT Qt::TimeZone America/Los_Angeles.yocto )
QDateTime(2021-11-01 04:00:00.000 PST Qt::TimeZone America/Los_Angeles.yocto )
QDateTime(2021-11-07 04:00:00.000 PST Qt::TimeZone America/Los_Angeles.yocto )
```

Output with normal Qt5 which is not affected with Mint TZ where Nov 1 is still in summer time:
```bash
$ ./dt America/Los_Angeles.mint
QDateTime(2021-10-31 05:00:00.000 PDT Qt::TimeZone America/Los_Angeles.mint )
QDateTime(2021-11-01 05:00:00.000 PDT Qt::TimeZone America/Los_Angeles.mint )
QDateTime(2021-11-07 04:00:00.000 PST Qt::TimeZone America/Los_Angeles.mint )
```

Output with patched Qt5 with yocto TZ:
```bash
$ ./dt America/Los_Angeles.yocto
QDateTime(2021-10-31 05:00:00.000 PDT Qt::TimeZone America/Los_Angeles.yocto )
QDateTime(2021-11-01 05:00:00.000 PDT Qt::TimeZone America/Los_Angeles.yocto )
QDateTime(2021-11-07 04:00:00.000 PST Qt::TimeZone America/Los_Angeles.yocto )
```
