### PR TITLE
qt5: set ALLOW_EMPTY for mkspecs subpackage

### DIFF
--- a/recipes-qt/qt5/qt5.inc
+++ b/recipes-qt/qt5/qt5.inc
@@ -53,6 +53,7 @@ INSANE_SKIP:${PN}-examples += "libdir staticdev dev-so"
 PACKAGES =. "${PN}-qmldesigner ${PN}-qmlplugins ${PN}-tools ${PN}-plugins ${PN}-mkspecs ${PN}-examples "
 
 ALLOW_EMPTY:${PN} = "1"
+ALLOW_EMPTY:${PN}-mkspecs = "1"
 ALLOW_EMPTY:${PN}-plugins = "1"
 ALLOW_EMPTY:${PN}-qmlplugins = "1"
 


### PR DESCRIPTION
Some recipes might not export mkspecs so set ALLOW_EMPTY.

This fixes a qt3d-mkspecs package missing issue during populating SDK.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>