### PR TITLE
[dunfell] qtbase: backport two elgfs fixes from qtbase upstream

### DIFF
--- a/recipes-qt/qt5/qtbase/0023-eglfs-kms-Query-the-current-mode-correctly-via-the-e.patch
+++ b/recipes-qt/qt5/qtbase/0023-eglfs-kms-Query-the-current-mode-correctly-via-the-e.patch
@@ -1,0 +1,33 @@
+From bd4a1b98b813dfbbb4a9db35a380bed8dd5f0ce3 Mon Sep 17 00:00:00 2001
+From: Laszlo Agocs <laszlo.agocs@qt.io>
+Date: Mon, 6 Jan 2020 10:50:33 +0100
+Subject: [PATCH] eglfs: kms: Query the current mode correctly via the encoder
+
+Upstream-Status: Backported
+
+...not the connector. Passing the connector id to drmModeGetEncoder()
+is clearly an oversight.
+
+Task-number: QTBUG-80976
+Change-Id: I80a6088fca558d1637bd01b0aca8c4a8ba3b25f5
+Reviewed-by: Eirik Aavitsland <eirik.aavitsland@qt.io>
+---
+ src/platformsupport/kmsconvenience/qkmsdevice.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/platformsupport/kmsconvenience/qkmsdevice.cpp b/src/platformsupport/kmsconvenience/qkmsdevice.cpp
+index b820fafd50..18f7b5e23b 100644
+--- a/src/platformsupport/kmsconvenience/qkmsdevice.cpp
++++ b/src/platformsupport/kmsconvenience/qkmsdevice.cpp
+@@ -262,7 +262,7 @@ QPlatformScreen *QKmsDevice::createScreenForConnector(drmModeResPtr resources,
+     // Get the current mode on the current crtc
+     drmModeModeInfo crtc_mode;
+     memset(&crtc_mode, 0, sizeof crtc_mode);
+-    if (drmModeEncoderPtr encoder = drmModeGetEncoder(m_dri_fd, connector->connector_id)) {
++    if (drmModeEncoderPtr encoder = drmModeGetEncoder(m_dri_fd, connector->encoder_id)) {
+         drmModeCrtcPtr crtc = drmModeGetCrtc(m_dri_fd, encoder->crtc_id);
+         drmModeFreeEncoder(encoder);
+ 
+-- 
+2.25.1
+

--- a/recipes-qt/qt5/qtbase/0024-eglfs_kms-Do-not-skip-the-initial-SetCrtc.patch
+++ b/recipes-qt/qt5/qtbase/0024-eglfs_kms-Do-not-skip-the-initial-SetCrtc.patch
@@ -1,0 +1,50 @@
+From f9e70f4905c5854bbae9c0b48ea8767312d96ca9 Mon Sep 17 00:00:00 2001
+From: Laszlo Agocs <laszlo.agocs@qt.io>
+Date: Wed, 29 Jul 2020 12:52:35 +0200
+Subject: [PATCH] eglfs_kms: Do not skip the initial SetCrtc
+
+Upstream-Status: Backported
+
+Trying to be clever seems to cause issues on some systems, for example
+AMD (RADV) on Ubuntu 20.04 gives totally garbled output by default.
+
+Remove the undocumented ALWAYS_SET_MODE env.var. as well, it won't have
+much of a purpose since we'll in effect hit the SetCrtc path always now
+once on startup.
+
+Change-Id: Ibaa463ff913eb0c1251d6d3435aa4799fe5c8a29
+Fixes: QTBUG-85797
+Reviewed-by: Andy Nichols <andy.nichols@qt.io>
+(cherry picked from commit 61bd046b5810b867f4b1fd07cf4d65d7d423534e)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+---
+ .../eglfs_kms/qeglfskmsgbmscreen.cpp                  | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms/qeglfskmsgbmscreen.cpp b/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms/qeglfskmsgbmscreen.cpp
+index 6f5c3b6953..95b51c9601 100644
+--- a/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms/qeglfskmsgbmscreen.cpp
++++ b/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms/qeglfskmsgbmscreen.cpp
+@@ -227,16 +227,11 @@ void QEglFSKmsGbmScreen::ensureModeSet(uint32_t fb)
+ 
+         bool doModeSet = true;
+         drmModeCrtcPtr currentMode = drmModeGetCrtc(fd, op.crtc_id);
+-        const bool alreadySet = currentMode && !memcmp(&currentMode->mode, &op.modes[op.mode], sizeof(drmModeModeInfo));
++        const bool alreadySet = currentMode && currentMode->buffer_id == fb && !memcmp(&currentMode->mode, &op.modes[op.mode], sizeof(drmModeModeInfo));
+         if (currentMode)
+             drmModeFreeCrtc(currentMode);
+-        if (alreadySet) {
+-            static bool alwaysDoSet = qEnvironmentVariableIntValue("QT_QPA_EGLFS_ALWAYS_SET_MODE");
+-            if (!alwaysDoSet) {
+-                qCDebug(qLcEglfsKmsDebug, "Mode already set, skipping modesetting for screen %s", qPrintable(name()));
+-                doModeSet = false;
+-            }
+-        }
++        if (alreadySet)
++            doModeSet = false;
+ 
+         if (doModeSet) {
+             qCDebug(qLcEglfsKmsDebug, "Setting mode for screen %s", qPrintable(name()));
+-- 
+2.25.1
+

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -35,6 +35,8 @@ SRC_URI += "\
     file://0017-eglfs-Prevent-printing-a-warning-in-every-widget-bas.patch \
     file://0018-input-Make-use-of-timeval-portable-for-64bit-time_t.patch \
     file://0022-tst_qpainter-FE_-macros-are-not-defined-for-every-pl.patch \
+    file://0023-eglfs-kms-Query-the-current-mode-correctly-via-the-e.patch \
+    file://0024-eglfs_kms-Do-not-skip-the-initial-SetCrtc.patch \
 "
 
 # for syncqt


### PR DESCRIPTION
To let eglfs_kms integration work, we need backport two patches from
qtbase upstream:
```
bd4a1b98: eglfs: kms: Query the current mode correctly via the encoder
f9e70f49: eglfs_kms: Do not skip the initial SetCrtc
```

Signed-off-by: Ming Liu <liu.ming50@gmail.com>