### PR TITLE
qtwebengine: fix build with newer icu+libxml

### DIFF
--- a/recipes-qt/qt5/qtwebengine/chromium/0023-chromium-remove-true-to-prep-landing-of-icu68.patch
+++ b/recipes-qt/qt5/qtwebengine/chromium/0023-chromium-remove-true-to-prep-landing-of-icu68.patch
@@ -1,0 +1,59 @@
+From e8aa87fa88f55e76ce08794690665ce30caa3183 Mon Sep 17 00:00:00 2001
+From: Frank Tang <ftang@chromium.org>
+Date: Tue, 20 Oct 2020 01:09:43 +0000
+Subject: [PATCH] Remove TRUE to prep landing of icu68
+
+ICU 68, to work with C++20, remove the #define of TRUE
+since the usage in libxml is as an int, use 1 instead.
+
+Upstream-Status: Backport [https://github.com/chromium/chromium/commit/e8aa87fa88f55e76ce08794690665ce30caa3183]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+---
+ chromium/third_party/libxml/README.chromium            |  2 ++
+ chromium/third_party/libxml/src/encoding.c             |  6 ++--
+ 3 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/chromium/third_party/libxml/README.chromium b/chromium/third_party/libxml/README.chromium
+index f84cc64e1f922..8da443a392c3d 100644
+--- a/chromium/third_party/libxml/README.chromium
++++ b/chromium/third_party/libxml/README.chromium
+@@ -24,6 +24,8 @@ Modifications:
+     non-recursive broke a few web platform tests.
+ - add-fuzz-target.patch: Prevents autoreconf from failing on mac due to a
+     missing makefile for fuzz.
++- chromium-issue-1138555.patch: Change TRUE to 1 for ICU68 which remove the
++  #define of TRUE.
+ - Add helper classes in the chromium/ subdirectory.
+ - Delete various unused files, see chromium/roll.py
+ 
+diff --git a/chromium/third_party/libxml/src/encoding.c b/chromium/third_party/libxml/src/encoding.c
+index c34aca44663c0..47be560ede472 100644
+--- a/chromium/third_party/libxml/src/encoding.c
++++ b/chromium/third_party/libxml/src/encoding.c
+@@ -1858,7 +1858,7 @@ xmlIconvWrapper(iconv_t cd, unsigned char *out, int *outlen,
+  * @outlen:  the length of @out
+  * @in:  a pointer to an array of input bytes
+  * @inlen:  the length of @in
+- * @flush: if true, indicates end of input
++ * @flush: if 1, indicates end of input
+  *
+  * Returns 0 if success, or
+  *     -1 by lack of space, or
+@@ -1898,7 +1898,7 @@ xmlUconvWrapper(uconv_t *cd, int toUnicode, unsigned char *out, int *outlen,
+     *inlen = ucv_in - (const char*) in;
+     *outlen = ucv_out - (char *) out;
+     if (U_SUCCESS(err)) {
+-        /* reset pivot buf if this is the last call for input (flush==TRUE) */
++        /* reset pivot buf if this is the last call for input (flush==1) */
+         if (flush)
+             cd->pivot_source = cd->pivot_target = cd->pivot_buf;
+         return 0;
+@@ -2004,7 +2004,7 @@ xmlEncOutputChunk(xmlCharEncodingHandler *handler, unsigned char *out,
+ #ifdef LIBXML_ICU_ENABLED
+     else if (handler->uconv_out != NULL) {
+         ret = xmlUconvWrapper(handler->uconv_out, 0, out, outlen, in, inlen,
+-                              TRUE);
++                              1);
+     }
+ #endif /* LIBXML_ICU_ENABLED */
+     else {

--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -179,6 +179,7 @@ SRC_URI += " \
     file://chromium/0008-chromium-Move-CharAllocator-definition-to-a-header-f.patch;patchdir=src/3rdparty \
     file://chromium/0009-chromium-Link-v8-with-libatomic-on-x86.patch;patchdir=src/3rdparty \
     file://chromium/0010-chromium-icu-use-system-library-only-targets.patch;patchdir=src/3rdparty \
+    file://chromium/0023-chromium-remove-true-to-prep-landing-of-icu68.patch;patchdir=src/3rdparty \
 "
 
 # Patches from https://github.com/meta-qt5/qtwebengine-chromium/commits/87-based


### PR DESCRIPTION
Replace TRUE with 1, because of TRUE removal from newer ICU.

Patch has been taken from https://github.com/chromium/chromium/commit/e8aa87fa88f55e76ce08794690665ce30caa3183

Signed-off-by: Andrej Valek <andrej.valek@siemens.com>