### PR TITLE
qtpdf: Fix build with clang

### DIFF
--- a/recipes-qt/qt5/qtpdf/0002-Remove-the-GN-settings-done-for-clang-that-conflict-.patch
+++ b/recipes-qt/qt5/qtpdf/0002-Remove-the-GN-settings-done-for-clang-that-conflict-.patch
@@ -1,0 +1,97 @@
+From cab3c06864569577158626e500b2253687fc09ba Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 29 Apr 2019 12:00:19 +0300
+Subject: [PATCH] Remove the GN settings done for clang that conflict with OE
+
+clang cross compiler that is build with meta-clang has lot of these
+settings built-in and specifying them here confuses the compiler
+
+--target option and -no-canonical-prefixes options result in clang
+
+finding the headers in target sysroot
+
+Upstream-Status: Inappropriate [OE-Specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Rebased-by: Maksim Sisov <msisov@igalia.com>
+---
+ src/3rdparty/chromium/build/config/compiler/BUILD.gn | 35 ----------------------------------
+ 1 file changed, 35 deletions(-)
+
+--- a/src/3rdparty/chromium/build/config/compiler/BUILD.gn
++++ b/src/3rdparty/chromium/build/config/compiler/BUILD.gn
+@@ -781,10 +781,6 @@ config("compiler_cpu_abi") {
+         ]
+       }
+     } else if (current_cpu == "arm") {
+-      if (is_clang && !is_android && !is_nacl) {
+-        cflags += [ "--target=arm-linux-gnueabihf" ]
+-        ldflags += [ "--target=arm-linux-gnueabihf" ]
+-      }
+       if (!is_nacl) {
+         cflags += [
+           "-march=$arm_arch",
+@@ -794,11 +790,6 @@ config("compiler_cpu_abi") {
+       if (arm_tune != "") {
+         cflags += [ "-mtune=$arm_tune" ]
+       }
+-    } else if (current_cpu == "arm64") {
+-      if (is_clang && !is_android && !is_nacl && !is_fuchsia) {
+-        cflags += [ "--target=aarch64-linux-gnu" ]
+-        ldflags += [ "--target=aarch64-linux-gnu" ]
+-      }
+     } else if (current_cpu == "mipsel" && !is_nacl) {
+       ldflags += [ "-Wl,--hash-style=sysv" ]
+       if (custom_toolchain == "") {
+@@ -806,9 +797,6 @@ config("compiler_cpu_abi") {
+           if (is_android) {
+             cflags += [ "--target=mipsel-linux-android" ]
+             ldflags += [ "--target=mipsel-linux-android" ]
+-          } else {
+-            cflags += [ "--target=mipsel-linux-gnu" ]
+-            ldflags += [ "--target=mipsel-linux-gnu" ]
+           }
+         } else {
+           cflags += [ "-EL" ]
+@@ -888,8 +876,6 @@ config("compiler_cpu_abi") {
+       ldflags += [ "-Wl,--hash-style=sysv" ]
+       if (custom_toolchain == "") {
+         if (is_clang) {
+-          cflags += [ "--target=mips-linux-gnu" ]
+-          ldflags += [ "--target=mips-linux-gnu" ]
+         } else {
+           cflags += [ "-EB" ]
+           ldflags += [ "-EB" ]
+@@ -937,9 +923,6 @@ config("compiler_cpu_abi") {
+           if (is_android) {
+             cflags += [ "--target=mips64el-linux-android" ]
+             ldflags += [ "--target=mips64el-linux-android" ]
+-          } else {
+-            cflags += [ "--target=mips64el-linux-gnuabi64" ]
+-            ldflags += [ "--target=mips64el-linux-gnuabi64" ]
+           }
+         } else {
+           cflags += [
+@@ -997,8 +980,6 @@ config("compiler_cpu_abi") {
+       ldflags += [ "-Wl,--hash-style=sysv" ]
+       if (custom_toolchain == "") {
+         if (is_clang) {
+-          cflags += [ "--target=mips64-linux-gnuabi64" ]
+-          ldflags += [ "--target=mips64-linux-gnuabi64" ]
+         } else {
+           cflags += [
+             "-EB",
+@@ -1166,13 +1147,6 @@ config("compiler_deterministic") {
+       }
+     }
+   }
+-
+-  # Tells the compiler not to use absolute paths when passing the default
+-  # paths to the tools it invokes. We don't want this because we don't
+-  # really need it and it can mess up the goma cache entries.
+-  if (is_clang && !is_nacl && !(use_qt && use_libcxx)) {
+-    cflags += [ "-no-canonical-prefixes" ]
+-  }
+ }
+ 
+ config("clang_revision") {

--- a/recipes-qt/qt5/qtpdf/native-clang.patch
+++ b/recipes-qt/qt5/qtpdf/native-clang.patch
@@ -1,0 +1,19 @@
+Fix building with clang from meta-clang
+
+Clang defaults to llvm runtime and this patch is needed
+for building the host tools, since its using native runtime
+
+Upstream-Status: Inappropriate [OE-Specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+--- a/src/buildtools/gn.pro
++++ b/src/buildtools/gn.pro
+@@ -20,7 +20,7 @@ build_pass|!debug_and_release {
+ 
+             gn_gen_args = --no-last-commit-position --out-path $$out_path \
+                           --cc \"$$which($$CC_host)\" --cxx \"$$which($$CXX_host)\" \
+-                          --ld \"$$which($$CXX_host)\" --ar \"$$which(ar)\" \
++                          --ld \"$$which($$CXX_host) -rtlib=libgcc -unwindlib=libgcc\" --ar \"$$which(ar)\" \
+                           --no-static-libstdc++
+ 
+             msvc:!clang_cl: gn_gen_args += --use-lto

--- a/recipes-qt/qt5/qtpdf_git.bb
+++ b/recipes-qt/qt5/qtpdf_git.bb
@@ -103,7 +103,7 @@ do_configure() {
         QMAKE_CFLAGS="${OE_QMAKE_CFLAGS}" \
         QMAKE_CXXFLAGS="${OE_QMAKE_CXXFLAGS}" \
         -after ${EXTRA_QMAKEVARS_POST} -- \
-        ${EXTRA_QMAKEVARS_CONFIGURE}
+        ${EXTRA_QMAKEVARS_CONFIGURE} -verbose
 }
 
 do_configure:prepend:libc-musl() {
@@ -142,6 +142,7 @@ SRC_URI += " \
     ${QT_GIT}/qtwebengine-chromium.git;name=chromium;branch=${QT_MODULE_BRANCH_CHROMIUM};protocol=${QT_GIT_PROTOCOL};destsuffix=git/src/3rdparty \
     file://0001-Force-host-toolchain-configuration.patch \
     file://0002-qmake.conf-lower-MODULE_VERSION-to-5.15.2.patch \
+    file://0002-Remove-the-GN-settings-done-for-clang-that-conflict-.patch \
 "
 # Patches from https://github.com/meta-qt5/qtwebengine/commits/b5.15
 # 5.15.meta-qt5.13

--- a/recipes-qt/qt5/qtpdf_git.bb
+++ b/recipes-qt/qt5/qtpdf_git.bb
@@ -151,6 +151,8 @@ SRC_URI:append:libc-musl = "\
     file://0005-mkspecs-Allow-builds-with-libc-glibc.patch \
 "
 
+SRC_URI:append:runtime-llvm = " file://native-clang.patch "
+
 SRCREV_qtwebengine = "73e76f9e86b3fded45be6b232bdebe75e7136e4a"
 SRCREV_chromium = "48a205f9e054b5cc3e67df2e25382da9460c0015"
 SRCREV = "${SRCREV_qtwebengine}"

--- a/recipes-qt/qt5/qtwebkit_git.bb
+++ b/recipes-qt/qt5/qtwebkit_git.bb
@@ -52,6 +52,7 @@ ARM_INSTRUCTION_SET:armv7ve = "thumb"
 # just use -fpermissive in this case like fedora did:
 # https://bugzilla.redhat.com/show_bug.cgi?id=1582954
 CXXFLAGS += "-fpermissive"
+CXXFLAGS += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', '-DEGL_NO_X11=1', d)}"
 
 EXTRA_OECMAKE += " \
     -DPORT=Qt \


### PR DESCRIPTION
use GNU runtime when building native tools like gn
when using native clang compiler

Fixes
| FAILED: gn
| /mnt/b/yoe/master/build/tmp/work/core2-64-yoe-linux/qtpdf/5.15.8+gitAUTOINC+73e76f9e86_48a205f9e0-r0/recipe-sysroot-native/usr/bin/clang++ -O3 -fdata-sections -ffunction-sections -Wl,--gc-sections -Wl,-stri
p-all -Wl,--as-needed -pthread -o gn -Wl,--start-group tools/gn/gn_main.o base.a gn_lib.a -Wl,--end-group -ldl
| /mnt/b/yoe/master/build/tmp/hosttools/ld: cannot find /usr/lib/clang/14.0.0/lib/linux/libclang_rt.builtins-x86_64.a: No such file or directory

Signed-off-by: Khem Raj <raj.khem@gmail.com>