### PR TITLE
qtwebengine: Add missing libxkbfile dependency

### DIFF
--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -23,7 +23,7 @@ DEPENDS += " \
     qtwebchannel \
     qtbase qtdeclarative qtxmlpatterns qtquickcontrols qtquickcontrols2 \
     qtlocation \
-    libdrm libxkbcommon fontconfig pixman openssl pango cairo pciutils nss \
+    libdrm libxkbcommon libxkbfile fontconfig pixman openssl pango cairo pciutils nss \
     libcap \
     jpeg-native \
     freetype-native \


### PR DESCRIPTION
The libxkbfile is a new dependency of qtwebengine 5.15.8 updated in commit
d38470c2 ("qtwebengine: upgrade to v5.15.8 and use the same SRCREVs as qtpdf")
Without libxkbfile dependency, the build fails with:

```
sed: can't read /.../qtwebengine/5.15.8+gitAUTOINC+73e76f9e86_48a205f9e0-r0/image/usr/lib/pkgconfig/Qt5WebEngineCore.pc: No such file or directory
```