### PR TITLE
qtwebengine: Add libxkbfile only when x11 is in distro features

### DIFF
--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -23,13 +23,13 @@ DEPENDS += " \
     qtwebchannel \
     qtbase qtdeclarative qtxmlpatterns qtquickcontrols qtquickcontrols2 \
     qtlocation \
-    libdrm libxkbcommon libxkbfile fontconfig pixman openssl pango cairo pciutils nss \
+    libdrm libxkbcommon fontconfig pixman openssl pango cairo pciutils nss \
     libcap \
     jpeg-native \
     freetype-native \
     gperf-native \
     ${@bb.utils.contains('DISTRO_FEATURES', 'alsa', 'alsa-lib', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'libxcomposite libxcursor libxi libxrandr libxtst', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'libxkbfile libxcomposite libxcursor libxi libxrandr libxtst', '', d)} \
 "
 
 DEPENDS:append:libc-musl = " libexecinfo"


### PR DESCRIPTION
Its needed for xcb platform which means its not needed when x11 is not
in distro features, limit the scope of this dependency to x11
fixes non-x11 builds

Signed-off-by: Khem Raj <raj.khem@gmail.com>