### PR TITLE
ogl-runtime: Check for ppc64 before ppc

### DIFF
--- a/recipes-connectivity/libconnman-qt/libconnman-qt5/0001-Add-missing-declarations-for-operator-overloads.patch
+++ b/recipes-connectivity/libconnman-qt/libconnman-qt5/0001-Add-missing-declarations-for-operator-overloads.patch
@@ -17,14 +17,12 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
 
 --- a/libconnman-qt/marshalutils.cpp
 +++ b/libconnman-qt/marshalutils.cpp
-@@ -36,6 +36,11 @@
+@@ -36,6 +36,9 @@
  
  #include "marshalutils.h"
  
-+#if defined(__clang__) &&  __clang_major__ >= 11
 +Q_DBUS_EXPORT const QDBusArgument &operator>>(const QDBusArgument &a, RouteStructure &v);
 +Q_DBUS_EXPORT QDBusArgument &operator<<(QDBusArgument &a, const RouteStructure &v);
-+#endif
 +
  // Empty namespace for local static functions
  namespace {

--- a/recipes-qt/maliit/maliit-framework-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-framework-qt5_git.bb
@@ -61,8 +61,8 @@ EXTRA_QMAKEVARS_PRE = "\
     CONFIG+=qt5-inputcontext \
 "
 
-# tests fail to build with clang
-EXTRA_QMAKEVARS_PRE:append:toolchain-clang = " CONFIG+=notests"
+# tests fail to build with gcc12/clang
+EXTRA_QMAKEVARS_PRE:append = " CONFIG+=notests"
 
 EXTRA_OEMAKE += "INSTALL_ROOT=${D}"
 

--- a/recipes-qt/maliit/maliit-plugins-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-plugins-qt5_git.bb
@@ -27,8 +27,8 @@ EXTRA_QMAKEVARS_PRE = "\
     CONFIG+=nodoc \
 "
 
-# tests fail to build with clang
-EXTRA_QMAKEVARS_PRE:append:toolchain-clang = " CONFIG+=notests"
+# tests fail to build with gcc12/clang
+EXTRA_QMAKEVARS_PRE:append = " CONFIG+=notests"
 
 FILES:${PN} += "\
     ${libdir}/maliit \

--- a/recipes-qt/qt5/ogl-runtime/0001-Qt3D-Add-support-to-fix-build-on-ppc64.patch
+++ b/recipes-qt/qt5/ogl-runtime/0001-Qt3D-Add-support-to-fix-build-on-ppc64.patch
@@ -10,24 +10,26 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  src/foundation/Qt3DSSystem.cpp     | 8 +++++++-
  2 files changed, 8 insertions(+), 2 deletions(-)
 
-diff --git a/src/foundation/Qt3DSPreprocessor.h b/src/foundation/Qt3DSPreprocessor.h
-index 066a38e..98ff573 100644
 --- a/src/foundation/Qt3DSPreprocessor.h
 +++ b/src/foundation/Qt3DSPreprocessor.h
-@@ -114,7 +114,7 @@ Platform define
+@@ -112,11 +112,11 @@ Platform define
+ #define QT3DS_VMX
+ #elif defined(__x86_64__)
  #define QT3DS_X64
- #elif defined(__ppc__)
- #define QT3DS_PPC
+-#elif defined(__ppc__)
+-#define QT3DS_PPC
 -#elif defined(__ppc64__)
 +#elif defined(__powerpc64__)
  #define QT3DS_PPC
  #define QT3DS_PPC64
++#elif defined(__ppc__)
++#define QT3DS_PPC
  //#   elif defined(__aarch64__)
-diff --git a/src/foundation/Qt3DSSystem.cpp b/src/foundation/Qt3DSSystem.cpp
-index e87a25e..81f563f 100644
+ //#       define QT3DS_ARM_64
+ #else
 --- a/src/foundation/Qt3DSSystem.cpp
 +++ b/src/foundation/Qt3DSSystem.cpp
-@@ -62,6 +62,10 @@ const char *qt3ds::foundation::System::g_FloatingPointModel = "";
+@@ -62,6 +62,10 @@ const char *qt3ds::foundation::System::g
  const char *qt3ds::foundation::System::g_Processor = "x64";
  const char *qt3ds::foundation::System::g_BitWidth = "64";
  const char *qt3ds::foundation::System::g_FloatingPointModel = "";
@@ -38,15 +40,27 @@ index e87a25e..81f563f 100644
  #elif defined(QT3DS_ARM)
  #if defined(__aarch64__) || defined(__ARM64__)
  const char *qt3ds::foundation::System::g_Processor = "arm";
-@@ -97,6 +101,8 @@ const char *qt3ds::foundation::System::g_GPUType = "gles3";
+@@ -79,7 +83,7 @@ const char *qt3ds::foundation::System::g
+ #endif
+ #endif
+ #else
+-#error "Unknown Platform"
++//#error "Unknown Platform"
+ #endif
+ 
+ #if defined(QT3DS_ARM)
+@@ -97,8 +101,10 @@ const char *qt3ds::foundation::System::g
  const char *qt3ds::foundation::System::g_GPUType = "";
  #elif defined(QT3DS_X64)
  const char *qt3ds::foundation::System::g_GPUType = "";
 +#elif defined(QT3DS_PPC64)
 +const char *qt3ds::foundation::System::g_GPUType = "";
  #else
- #error "Must define a processor type (QT3DS_ARM or QT3DS_X86)"
+-#error "Must define a processor type (QT3DS_ARM or QT3DS_X86)"
++//#error "Must define a processor type (QT3DS_ARM or QT3DS_X86)"
  #endif
+ 
+ namespace {
 @@ -136,4 +142,4 @@ const char *System::getPlatformGLStr()
          strcpy(text, str.c_str());
      }
@@ -54,6 +68,3 @@ index e87a25e..81f563f 100644
 -}
 \ No newline at end of file
 +}
--- 
-2.30.2
-


### PR DESCRIPTION
since compiler for ppc64 defines both ppc and ppc64 its better to
check for ppc64 first

Signed-off-by: Khem Raj <raj.khem@gmail.com>