### PR TITLE
qt5-creator: add pkgconfig to inherit

### DIFF
--- a/recipes-qt/qt5/qt5-creator_git.bb
+++ b/recipes-qt/qt5/qt5-creator_git.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = " \
     file://LICENSE.GPL3-EXCEPT;md5=763d8c535a234d9a3fb682c7ecb6c073 \
 "
 
-inherit qmake5 mime-xdg
+inherit qmake5 pkgconfig mime-xdg
 
 DEPENDS += "qtbase qtscript qtxmlpatterns qtx11extras qtdeclarative qttools qttools-native qtsvg chrpath-replacement-native zlib"
 DEPENDS:append:libc-musl = " libexecinfo"


### PR DESCRIPTION
Fixes many complaints in configure as:
| sh: line 1: pkg-config: command not found

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>