### PR TITLE
[dunfell] qtdeclarative: Fix build with gcc-11

### DIFF
--- a/recipes-qt/qt5/qtdeclarative/0003-qv4regexp_p-needs-c-limits-include-instead-of-plain-.patch
+++ b/recipes-qt/qt5/qtdeclarative/0003-qv4regexp_p-needs-c-limits-include-instead-of-plain-.patch
@@ -1,0 +1,41 @@
+From bfd3d907f48aba870be00cd251f0b63d34985be2 Mon Sep 17 00:00:00 2001
+From: Peter Seiderer <ps.report at gmx.net>
+Date: Thu, 22 Jul 2021 23:02:29 +0200
+Subject: [PATCH] qv4regexp_p: needs c++ limits include (instead of plain c
+ limit.h)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes gcc-11 compile:
+
+  In file included from jsruntime/qv4regexp_p.h:62,
+                   from jsruntime/qv4regexp.cpp:40:
+  ../3rdparty/masm/yarr/Yarr.h:46:44: error: ‘numeric_limits’ is not a member of ‘std’
+     46 | static const unsigned offsetNoMatch = std::numeric_limits<unsigned>::max();
+        |                                            ^~~~~~~~~~~~~~
+  ../3rdparty/masm/yarr/Yarr.h:46:59: error: expected primary-expression before ‘unsigned’
+     46 | static const unsigned offsetNoMatch = std::numeric_limits<unsigned>::max();
+        |                                                           ^~~~~~~~
+
+Signed-off-by: Peter Seiderer <ps.report at gmx.net>
+---
+ src/qml/jsruntime/qv4regexp_p.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/qml/jsruntime/qv4regexp_p.h b/src/qml/jsruntime/qv4regexp_p.h
+index 6afb10ea95..c64f3d3c38 100644
+--- a/src/qml/jsruntime/qv4regexp_p.h
++++ b/src/qml/jsruntime/qv4regexp_p.h
+@@ -57,7 +57,7 @@
+ #include <wtf/FastAllocBase.h>
+ #include <wtf/BumpPointerAllocator.h>
+ 
+-#include <limits.h>
++#include <limits>
+ 
+ #include <yarr/Yarr.h>
+ #include <yarr/YarrInterpreter.h>
+-- 
+2.32.0
+

--- a/recipes-qt/qt5/qtdeclarative/0004-qqmlprofilerevent_p-needs-c-limits-inlcude-fixes-gcc.patch
+++ b/recipes-qt/qt5/qtdeclarative/0004-qqmlprofilerevent_p-needs-c-limits-inlcude-fixes-gcc.patch
@@ -1,0 +1,45 @@
+From cc8d62f556c065d28a52e4b784b5d22f2cca3001 Mon Sep 17 00:00:00 2001
+From: Peter Seiderer <ps.report at gmx.net>
+Date: Thu, 22 Jul 2021 23:13:43 +0200
+Subject: [PATCH] qqmlprofilerevent_p: needs c++ limits inlcude (fixes gcc-11
+ compile)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes:
+
+  In file included from qqmlprofilertypedevent_p.h:43,
+                   from qqmlprofilertypedevent.cpp:40:
+  qqmlprofilerevent_p.h: In member function ‘void QQmlProfilerEvent::assignNumbers(const Container&)’:
+  qqmlprofilerevent_p.h:314:65: error: ‘numeric_limits’ is not a member of ‘std’
+    314 |                     static_cast<quint16>(numbers.size()) : std::numeric_limits<quint16>::max();
+        |                                                                 ^~~~~~~~~~~~~~
+  qqmlprofilerevent_p.h:314:87: error: expected primary-expression before ‘>’ token
+    314 |                     static_cast<quint16>(numbers.size()) : std::numeric_limits<quint16>::max();
+        |                                                                                       ^
+  qqmlprofilerevent_p.h:314:90: error: ‘::max’ has not been declared; did you mean ‘std::max’?
+    314 |                     static_cast<quint16>(numbers.size()) : std::numeric_limits<quint16>::max();
+        |                                                                                          ^~~
+        |                                                                                          std::max
+
+Signed-off-by: Peter Seiderer <ps.report at gmx.net>
+---
+ src/qmldebug/qqmlprofilerevent_p.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/qmldebug/qqmlprofilerevent_p.h b/src/qmldebug/qqmlprofilerevent_p.h
+index a7e37d1964..01b2f58f16 100644
+--- a/src/qmldebug/qqmlprofilerevent_p.h
++++ b/src/qmldebug/qqmlprofilerevent_p.h
+@@ -48,6 +48,7 @@
+ #include <QtCore/qmetatype.h>
+ 
+ #include <initializer_list>
++#include <limits>
+ #include <type_traits>
+ 
+ //
+-- 
+2.32.0
+

--- a/recipes-qt/qt5/qtdeclarative_git.bb
+++ b/recipes-qt/qt5/qtdeclarative_git.bb
@@ -17,6 +17,8 @@ LIC_FILES_CHKSUM = " \
 SRC_URI += " \
     file://0001-Use-OE_QMAKE_PATH_EXTERNAL_HOST_BINS-to-locate-qmlca.patch \
     file://0002-Use-python3-explicitly.patch \
+    file://0003-qv4regexp_p-needs-c-limits-include-instead-of-plain-.patch \
+    file://0004-qqmlprofilerevent_p-needs-c-limits-inlcude-fixes-gcc.patch \
 "
 
 DEPENDS += "qtbase"


### PR DESCRIPTION
This fixes errors when trying to build qtdeclarative-native with GCC 11. Similarly to the qtbase fixes, the build errors are caused by missing `<limits>` includes.

Source of the patches:

https://lists.buildroot.org/pipermail/buildroot/2021-July/617465.html