### PR TITLE
libconnman-qt5: Apply operator patch for all compilers

### DIFF
--- a/recipes-connectivity/libconnman-qt/libconnman-qt5/0001-Add-missing-declarations-for-operator-overloads.patch
+++ b/recipes-connectivity/libconnman-qt/libconnman-qt5/0001-Add-missing-declarations-for-operator-overloads.patch
@@ -21,7 +21,7 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  
  #include "marshalutils.h"
  
-+#if defined(__clang__) &&  __clang_major__ >= 11
++#if defined(__clang__) &&  __clang_major__ >= 11 || __GNUC__ >= 12
 +Q_DBUS_EXPORT const QDBusArgument &operator>>(const QDBusArgument &a, RouteStructure &v);
 +Q_DBUS_EXPORT QDBusArgument &operator<<(QDBusArgument &a, const RouteStructure &v);
 +#endif

--- a/recipes-qt/examples/cinematicexperience_1.0.bb
+++ b/recipes-qt/examples/cinematicexperience_1.0.bb
@@ -24,10 +24,12 @@ RDEPENDS:${PN} = "liberation-fonts qtdeclarative-qmlplugins qtgraphicaleffects-q
 require recipes-qt/qt5/qt5.inc
 
 do_install() {
-    install -d ${D}${datadir}/${P}
-    install -m 0755 ${B}/Qt5_CinematicExperience ${D}${datadir}/${P}
-    cp -R --no-dereference --preserve=mode,links ${S}/content ${D}${datadir}/${P}
-    install -m 0644 ${S}/Qt5_CinematicExperience.qml ${D}${datadir}/${P}
+    install -d ${D}${datadir}/${P}/content/ ${D}${datadir}/${P}/content/images/
+    install -m 0755 ${B}/Qt5_CinematicExperience ${D}${datadir}/${P}/Qt5_CinematicExperience
+    install -m 0644 ${S}/content/*.qml ${D}${datadir}/${P}/content/
+    install -m 0644 ${S}/content/images/*.png ${D}${datadir}/${P}/content/images/
+    install -m 0644 ${S}/content/images/*.xcf ${D}${datadir}/${P}/content/images/
+    install -m 0644 ${S}/Qt5_CinematicExperience.qml ${D}${datadir}/${P}/Qt5_CinematicExperience.qml
 
     install -d ${D}${bindir}
     echo "#!/bin/sh" > ${D}${bindir}/Qt5_CinematicExperience


### PR DESCRIPTION
gcc12 has started to fail with same error like clang, perhaps this
should be upstreamed too

usr/include/QtDBus/qdbusargument.h:276:13: error: no match for 'operator>>' (operand types are 'const QDBusArgument' and 'RouteStructure')
|   276 |         arg >> item;
|       |         ~~~~^~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>
Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>