### PR TITLE
cinematicexperience: Fix file permisions for non-root user

### DIFF
--- a/recipes-qt/examples/cinematicexperience_1.0.bb
+++ b/recipes-qt/examples/cinematicexperience_1.0.bb
@@ -24,10 +24,12 @@ RDEPENDS:${PN} = "liberation-fonts qtdeclarative-qmlplugins qtgraphicaleffects-q
 require recipes-qt/qt5/qt5.inc
 
 do_install() {
-    install -d ${D}${datadir}/${P}
-    install -m 0755 ${B}/Qt5_CinematicExperience ${D}${datadir}/${P}
-    cp -R --no-dereference --preserve=mode,links ${S}/content ${D}${datadir}/${P}
-    install -m 0644 ${S}/Qt5_CinematicExperience.qml ${D}${datadir}/${P}
+    install -d ${D}${datadir}/${P}/content/ ${D}${datadir}/${P}/content/images/
+    install -m 0755 ${B}/Qt5_CinematicExperience ${D}${datadir}/${P}/Qt5_CinematicExperience
+    install -m 0644 ${S}/content/*.qml ${D}${datadir}/${P}/content/
+    install -m 0644 ${S}/content/images/*.png ${D}${datadir}/${P}/content/images/
+    install -m 0644 ${S}/content/images/*.xcf ${D}${datadir}/${P}/content/images/
+    install -m 0644 ${S}/Qt5_CinematicExperience.qml ${D}${datadir}/${P}/Qt5_CinematicExperience.qml
 
     install -d ${D}${bindir}
     echo "#!/bin/sh" > ${D}${bindir}/Qt5_CinematicExperience


### PR DESCRIPTION
When running this demo under non-root user it often does not come up
because the asset are non-readable for non-root users e.g. weston user
when running weston based images.

Fixes
raspberrypi4-64:/usr/share/cinematicexperience-1.0$ ./Qt5_CinematicExperience
file:///usr/share/cinematicexperience-1.0/Qt5_CinematicExperience.qml:30:5: Type InfoView unavailable
         InfoView {
         ^
file:///usr/share/cinematicexperience-1.0/content/InfoView.qml: Permission denied
^C

buildhistory view after the change

--- a/packages/cortexa72-yoe-linux-musl/cinematicexperience/sysroot
+++ b/packages/cortexa72-yoe-linux-musl/cinematicexperience/sysroot
@@ -5,11 +5,11 @@ drwxr-xr-x -          -                4096 ./usr/share
 drwxr-xr-x -          -                4096 ./usr/share/cinematicexperience-1.0
 drwxr-xr-x -          -                4096 ./usr/share/cinematicexperience-1.0/content
 -rw-r--r-- -          -                1184 ./usr/share/cinematicexperience-1.0/content/Background.qml
--rw------- -          -                2868 ./usr/share/cinematicexperience-1.0/content/Button.qml
--rw------- -          -                1777 ./usr/share/cinematicexperience-1.0/content/CurtainEffect.qml
+-rw-r--r-- -          -                2868 ./usr/share/cinematicexperience-1.0/content/Button.qml
+-rw-r--r-- -          -                1777 ./usr/share/cinematicexperience-1.0/content/CurtainEffect.qml
 -rw-r--r-- -          -                3284 ./usr/share/cinematicexperience-1.0/content/DelegateItem.qml
 -rw-r--r-- -          -                5499 ./usr/share/cinematicexperience-1.0/content/DetailsView.qml
--rw------- -          -                 844 ./usr/share/cinematicexperience-1.0/content/FpsItem.qml
+-rw-r--r-- -          -                 844 ./usr/share/cinematicexperience-1.0/content/FpsItem.qml
 drwxr-xr-x -          -                4096 ./usr/share/cinematicexperience-1.0/content/images
 -rw-r--r-- -          -               88497 ./usr/share/cinematicexperience-1.0/content/images/10.png
 -rw-r--r-- -          -              106319 ./usr/share/cinematicexperience-1.0/content/images/11.png
@@ -63,11 +63,11 @@ drwxr-xr-x -          -                4096 ./usr/share/cinematicexperience-1.0/
 -rw-r--r-- -          -                5854 ./usr/share/cinematicexperience-1.0/content/images/switch_frame.png
 -rw-r--r-- -          -                2383 ./usr/share/cinematicexperience-1.0/content/images/switch_on.png
 -rw-r--r-- -          -                3366 ./usr/share/cinematicexperience-1.0/content/images/switch_thumb.png
--rw------- -          -                 727 ./usr/share/cinematicexperience-1.0/content/InfoViewItem.qml
--rw------- -          -               10046 ./usr/share/cinematicexperience-1.0/content/InfoView.qml
+-rw-r--r-- -          -                 727 ./usr/share/cinematicexperience-1.0/content/InfoViewItem.qml
+-rw-r--r-- -          -               10046 ./usr/share/cinematicexperience-1.0/content/InfoView.qml
 -rw-r--r-- -          -                8136 ./usr/share/cinematicexperience-1.0/content/MainView.qml
--rw------- -          -               15431 ./usr/share/cinematicexperience-1.0/content/MoviesModel.qml
--rw------- -          -                 794 ./usr/share/cinematicexperience-1.0/content/RatingsItem.qml
+-rw-r--r-- -          -               15431 ./usr/share/cinematicexperience-1.0/content/MoviesModel.qml
+-rw-r--r-- -          -                 794 ./usr/share/cinematicexperience-1.0/content/RatingsItem.qml
 -rw-r--r-- -          -                4155 ./usr/share/cinematicexperience-1.0/content/SettingsView.qml
 -rw-r--r-- -          -                5020 ./usr/share/cinematicexperience-1.0/content/Switch.qml
 -rwxr-xr-x -          -                9960 ./usr/share/cinematicexperience-1.0/Qt5_CinematicExperience

Signed-off-by: Khem Raj <raj.khem@gmail.com>