### PR TITLE
Workaround too eager packagegroup sanity check

### DIFF
--- a/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
+++ b/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
@@ -3,6 +3,9 @@
 SUMMARY = "Host packages for the Qt5 standalone SDK or external toolchain"
 LICENSE = "MIT"
 
+# disable sanity check for allarch packagegroup
+PACKAGE_ARCH = ""
+
 inherit packagegroup nativesdk
 
 PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"


### PR DESCRIPTION
Fix for error #467 

After oe-core/5bf3e447d2f5064495d83a8fad30229bcf1ecc9b change allarch
packagegroups are sanity checked. Nativesdk packagegroups should be
excluded for that check, add workaround to avoid errors: "An allarch
packagegroup shouldn't depend on packages which are dynamically renamed"