### PR TITLE
qtwebengine: Fix archiver assignment

### DIFF
--- a/recipes-qt/qt5/qtwebengine/0001-Force-host-toolchain-configuration.patch
+++ b/recipes-qt/qt5/qtwebengine/0001-Force-host-toolchain-configuration.patch
@@ -74,14 +74,14 @@ diff --git a/src/buildtools/gn.pro b/src/buildtools/gn.pro
 index f94694da0..5094574ed 100644
 --- a/src/buildtools/gn.pro
 +++ b/src/buildtools/gn.pro
-@@ -19,8 +19,8 @@ build_pass|!debug_and_release {
+@@ -19,9 +19,8 @@ build_pass|!debug_and_release {
              gn_bootstrap = $$system_path($$absolute_path(gn/build/gen.py, $$src_3rd_party_dir))
  
              gn_gen_args = --no-last-commit-position --out-path $$out_path \
 -                          --cc \"$$which($$QMAKE_CC)\" --cxx \"$$which($$QMAKE_CXX)\" \
 -                          --ld \"$$which($$QMAKE_LINK)\"
+-            !isEmpty(QMAKE_AR): gn_gen_args += --ar \"$$which($$first(QMAKE_AR))\"
 +                          --cc \"$$which($$CC_host)\" --cxx \"$$which($$CXX_host)\" \
 +                          --ld \"$$which($$CXX_host)\" --ar \"$$which(ar)\"
-             !isEmpty(QMAKE_AR): gn_gen_args += --ar \"$$which($$first(QMAKE_AR))\"
  
              msvc:!clang_cl: gn_gen_args += --use-lto


### PR DESCRIPTION
This qtwebengine GN patch already assigns AR correctly one line above
to '--ar \"$$which(ar)\"' , drop the newly added upstream AR assignment
as it triggers build failure:

"
[184/187] CXX tools/gn/target.o
[185/187] CXX tools/gn/visual_studio_writer.o
[186/187] AR gn_lib.a
[187/187] LINK gn
FAILED: gn
/build/tmp/hosttools/g++ -O3 -fdata-sections -ffunction-sections -Wl,--gc-sections -Wl,-strip-all -Wl,--as-needed -static-libstdc++ -pthread -o gn -Wl,--start-group tools/gn/gn_main.o base.a gn_lib.a -Wl,--end-group -ldl
/build/tmp/hosttools/ld: base.a: error adding symbols: archive has no index; run ranlib to add one
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
Project ERROR: GN build error!
make[2]: *** [Makefile:98: sub-gn-pro-make_first] Error 3
"