### PR TITLE
qtpdf: Do not add -rtlib=libgcc -unwindlib=libgcc when using gcc

### DIFF
--- a/recipes-qt/qt5/qtpdf/0002-gn.pro-do-not-try-to-statically-link-stdc.patch
+++ b/recipes-qt/qt5/qtpdf/0002-gn.pro-do-not-try-to-statically-link-stdc.patch
@@ -7,8 +7,6 @@ Subject: [PATCH] gn.pro: do not try to statically link stdc++
  src/buildtools/gn.pro | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
-diff --git a/src/buildtools/gn.pro b/src/buildtools/gn.pro
-index 5094574ed..7b8365157 100644
 --- a/src/buildtools/gn.pro
 +++ b/src/buildtools/gn.pro
 @@ -20,7 +20,8 @@ build_pass|!debug_and_release {
@@ -17,7 +15,7 @@ index 5094574ed..7b8365157 100644
                            --cc \"$$which($$CC_host)\" --cxx \"$$which($$CXX_host)\" \
 -                          --ld \"$$which($$CXX_host)\" --ar \"$$which(ar)\"
 +                          --ld \"$$which($$CXX_host)\" --ar \"$$which(ar)\" \
-+                          --no-static-libstdc++
-             !isEmpty(QMAKE_AR): gn_gen_args += --ar \"$$which($$first(QMAKE_AR))\"
++			  --no-static-libstdc++
  
              msvc:!clang_cl: gn_gen_args += --use-lto
+ 

--- a/recipes-qt/qt5/qtpdf/0003-Fix-build-with-clang.patch
+++ b/recipes-qt/qt5/qtpdf/0003-Fix-build-with-clang.patch
@@ -24,8 +24,6 @@ Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
  src/buildtools/gn.pro | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/src/buildtools/gn.pro b/src/buildtools/gn.pro
-index 7b8365157..51574e0fd 100644
 --- a/src/buildtools/gn.pro
 +++ b/src/buildtools/gn.pro
 @@ -20,7 +20,7 @@ build_pass|!debug_and_release {
@@ -34,6 +32,6 @@ index 7b8365157..51574e0fd 100644
                            --cc \"$$which($$CC_host)\" --cxx \"$$which($$CXX_host)\" \
 -                          --ld \"$$which($$CXX_host)\" --ar \"$$which(ar)\" \
 +                          --ld \"$$which($$CXX_host) -rtlib=libgcc -unwindlib=libgcc\" --ar \"$$which(ar)\" \
-                           --no-static-libstdc++
-             !isEmpty(QMAKE_AR): gn_gen_args += --ar \"$$which($$first(QMAKE_AR))\"
+ 			  --no-static-libstdc++
  
+             msvc:!clang_cl: gn_gen_args += --use-lto

--- a/recipes-qt/qt5/qtpdf_git.bb
+++ b/recipes-qt/qt5/qtpdf_git.bb
@@ -208,7 +208,7 @@ SRC_URI += " \
     file://0001-configure.json-remove-python2-dependency.patch \
     file://0002-gn.pro-do-not-try-to-statically-link-stdc.patch \
 "
-SRC_URI:append:runtime-llvm = " file://0003-Fix-build-with-clang.patch"
+SRC_URI:append:toolchain-clang:runtime-llvm = " file://0003-Fix-build-with-clang.patch"
 
 # These flags below go more into detail than qtwebengine's documentation
 PACKAGECONFIG[no-core] = "-no-build-qtwebengine-core,,"

--- a/recipes-qt/qt5/qtwebengine/0001-Force-host-toolchain-configuration.patch
+++ b/recipes-qt/qt5/qtwebengine/0001-Force-host-toolchain-configuration.patch
@@ -74,14 +74,14 @@ diff --git a/src/buildtools/gn.pro b/src/buildtools/gn.pro
 index f94694da0..5094574ed 100644
 --- a/src/buildtools/gn.pro
 +++ b/src/buildtools/gn.pro
-@@ -19,8 +19,8 @@ build_pass|!debug_and_release {
+@@ -19,9 +19,8 @@ build_pass|!debug_and_release {
              gn_bootstrap = $$system_path($$absolute_path(gn/build/gen.py, $$src_3rd_party_dir))
  
              gn_gen_args = --no-last-commit-position --out-path $$out_path \
 -                          --cc \"$$which($$QMAKE_CC)\" --cxx \"$$which($$QMAKE_CXX)\" \
 -                          --ld \"$$which($$QMAKE_LINK)\"
+-            !isEmpty(QMAKE_AR): gn_gen_args += --ar \"$$which($$first(QMAKE_AR))\"
 +                          --cc \"$$which($$CC_host)\" --cxx \"$$which($$CXX_host)\" \
 +                          --ld \"$$which($$CXX_host)\" --ar \"$$which(ar)\"
-             !isEmpty(QMAKE_AR): gn_gen_args += --ar \"$$which($$first(QMAKE_AR))\"
  
              msvc:!clang_cl: gn_gen_args += --use-lto


### PR DESCRIPTION
We need to also check for compiler along with runtime to apply this
patch so we dont accidentally add these options when using TOOLCHAIN =
"gcc"

Signed-off-by: Khem Raj <raj.khem@gmail.com>