### PR TITLE
qmake5_base.bbclass: Remove remove-libtool from recipe scope

### DIFF
--- a/classes/qmake5_base.bbclass
+++ b/classes/qmake5_base.bbclass
@@ -46,7 +46,7 @@ export OE_QMAKE_STRIP = "echo"
 # qmake reads if from shell environment
 export OE_QMAKE_QTCONF_PATH = "${WORKDIR}/qt.conf"
 
-inherit qmake5_paths remove-libtool
+inherit qmake5_paths
 
 generate_target_qt_config_file() {
     qtconf="$1"


### PR DESCRIPTION
Its a global setting

Signed-off-by: Khem Raj <raj.khem@gmail.com>