### PR TITLE
Remove QMAKE_PRL_BUILD_DIR from prl files

### DIFF
--- a/classes/qmake5_base.bbclass
+++ b/classes/qmake5_base.bbclass
@@ -246,7 +246,8 @@ qmake5_base_do_install() {
     # Replace host paths with qmake built-in properties
     find ${D} \( -name "*.pri" -or -name "*.prl" \) -exec \
         sed -i -e 's|${STAGING_DIR_NATIVE}|$$[QT_HOST_PREFIX/get]|g' \
-            -e 's|${STAGING_DIR_HOST}|$$[QT_SYSROOT]|g' {} \;
+            -e 's|${STAGING_DIR_HOST}|$$[QT_SYSROOT]|g' {} \
+            -e '/QMAKE_PRL_BUILD_DIR/d' {} \;
 
     # Replace host paths with pkg-config built-in variable
     find ${D} -name "*.pc" -exec \


### PR DESCRIPTION
Reduce warnings from buildpaths QA test (contains reference to TMPDIR) by removing QMAKE_PRL_BUILD_DIR from prl files.

Same as in meta-qt6: https://code.qt.io/cgit/yocto/meta-qt6.git/commit/?id=8fb6c082