### PR TITLE
qtwayland: Bump version to v5.15.7-lts-lgpl

### DIFF
--- a/recipes-qt/qt5/qtwayland_git.bb
+++ b/recipes-qt/qt5/qtwayland_git.bb
@@ -49,7 +49,7 @@ PACKAGECONFIG[wayland-vulkan-server-buffer] = "-feature-wayland-vulkan-server-bu
 
 EXTRA_QMAKEVARS_CONFIGURE += "${PACKAGECONFIG_CONFARGS}"
 
-SRCREV = "f1e6c8764d187e9c1c642f6b11020ea513822cd1"
+SRCREV = "533fff12f7c4beb177b56b766c71b1c7384e6229"
 
 BBCLASSEXTEND =+ "native nativesdk"
 


### PR DESCRIPTION
There is a build error with the v5.15.4-lts-lgpl version and xkbcommon.  The bug was fixed in the next LTS, so go ahead and move to the latest version available.

This should also address an open issue:

https://github.com/meta-qt5/meta-qt5/issues/484

Signed-off-by: Ryan Eatmon <reatmon@ti.com>