### PR TITLE
Update the repo URL

### DIFF
--- a/recipes-qt/qt5/qt5-git.inc
+++ b/recipes-qt/qt5/qt5-git.inc
@@ -7,7 +7,7 @@ QT_MODULE_BRANCH_PARAM ?= "branch=${QT_MODULE_BRANCH}"
 
 # each module needs to define valid SRCREV
 SRC_URI = " \
-    ${QT_GIT}/${QT_MODULE}.git;name=${QT_MODULE};${QT_MODULE_BRANCH_PARAM};protocol=${QT_GIT_PROTOCOL} \
+    ${QT_GIT}/qt/${QT_MODULE}.git;name=${QT_MODULE};${QT_MODULE_BRANCH_PARAM};protocol=${QT_GIT_PROTOCOL} \
 "
 
 CVE_PRODUCT = "qt"


### PR DESCRIPTION
The URL for Qt repos is changed to git://code.qt.io/qt/

Avoid WARNING: qtbase-native-5.15.7+gitAUTOINC+358aebba72-r0 do_fetch: Failed to fetch URL git://code.qt.i o/qtbase.git;name=qtbase;branch=5.15;protocol=git