### PR TITLE
Set proper string composition to fetch URL

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -36,6 +36,6 @@ LICENSE_PATH += "${LAYERDIR}/licenses"
 IMAGE_FEATURES[validitems] += "qtcreator-debug"
 
 QT_GIT_PROJECT ?= "qt"
-QT_GIT ?= "git://code.qt.io/${QT_GIT_PROJECT}"
+QT_GIT = "git://code.qt.io/${QT_GIT_PROJECT}"
 QT_GIT_PROTOCOL ?= "git"
 QT_EDITION ?= "opensource"


### PR DESCRIPTION
Using the previous QT_GIT setting with ?= cause a failure downloading several repos.

This avoid ERROR and WARNING: qtbase and others, do_fetch: Failed to fetch URL git://code.qt.io/qtbase.git;name=qtbase;branch=5.15;protocol=git