### PR TITLE
qt5-git: do not override CVE products

### DIFF
--- a/recipes-qt/qt5/qt5-git.inc
+++ b/recipes-qt/qt5/qt5-git.inc
@@ -10,7 +10,7 @@ SRC_URI = " \
     ${QT_GIT}/${QT_MODULE}.git;name=${QT_MODULE};${QT_MODULE_BRANCH_PARAM};protocol=${QT_GIT_PROTOCOL} \
 "
 
-CVE_PRODUCT = "qt"
+CVE_PRODUCT:append = " qt"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Some components use also base name in NVD CVE database product:
```
sqlite> select * from products where product like 'qtbase';
CVE-2019-18281|qt|qtbase|5.11.0|>=|5.11.3|<=
CVE-2019-18281|qt|qtbase|5.12.0|>=|5.12.5|<
sqlite> select * from products where product like 'qtsvg';
CVE-2021-45930|qt|qtsvg|5.0.0|>=|5.15.2|<=
CVE-2021-45930|qt|qtsvg|6.0.0|>=|6.2.1|<=
```
Changes for `meta-qt6` have been sent to `qt6/dev` branch. 