### PR TITLE
qtquick3d: Update assimp SRC_URI

### DIFF
--- a/recipes-qt/qt5/qtquick3d_git.bb
+++ b/recipes-qt/qt5/qtquick3d_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = " \
 DEPENDS += "qtbase qtdeclarative qtquickcontrols2"
 
 SRC_URI += " \
-    git://github.com/assimp/assimp.git;name=assimp;branch=assimp_5.0_release;protocol=https;destsuffix=git/src/3rdparty/assimp/src \
+    git://code.qt.io/qt/qtquick3d-assimp.git;name=assimp;branch=qt6_assimp;protocol=https;destsuffix=git/src/3rdparty/assimp/src \
 "
 
 PACKAGECONFIG ??= ""


### PR DESCRIPTION
The previous branch has been removed from the specified repo.  Updating to a code.qt.io repo and branch that still contains the requested SRCREV.