### PR TITLE
qtbase: Backport patch for CVE-2023-24607.

### DIFF
--- a/recipes-qt/qt5/qtbase/0026-qsql_odbc-Patch-for-CVE-2023-24607.patch
+++ b/recipes-qt/qt5/qtbase/0026-qsql_odbc-Patch-for-CVE-2023-24607.patch
@@ -1,0 +1,348 @@
+From 6873643ac7cba4338336a613cbe3d6fee8f26248 Mon Sep 17 00:00:00 2001
+From: Charlie Johnston <charlie.johnston@ni.com>
+Date: Fri, 23 Jun 2023 12:04:16 -0500
+Subject: [PATCH] qsql_odbc: Patch for CVE-2023-24607
+
+The fix for CVE-2023-24607 was only applied to qtbase
+5.15.13 and later. This backports the patch to versions
+of qtbase that are available in the GitHub meta-qt5 fork.
+
+CVE: CVE-2023-24607
+
+Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>
+Upstream-status: Backport
+---
+ src/plugins/sqldrivers/odbc/qsql_odbc.cpp | 206 +++++++++++++---------
+ 1 file changed, 118 insertions(+), 88 deletions(-)
+
+diff --git a/src/plugins/sqldrivers/odbc/qsql_odbc.cpp b/src/plugins/sqldrivers/odbc/qsql_odbc.cpp
+index 5f51de3843..6cac60d03d 100644
+--- a/src/plugins/sqldrivers/odbc/qsql_odbc.cpp
++++ b/src/plugins/sqldrivers/odbc/qsql_odbc.cpp
+@@ -92,23 +92,39 @@ inline static QString fromSQLTCHAR(const QVarLengthArray<SQLTCHAR>& input, int s
+     return result;
+ }
+ 
++template <size_t SizeOfChar = sizeof(SQLTCHAR)>
++void toSQLTCHARImpl(QVarLengthArray<SQLTCHAR> &result, const QString &input); // primary template undefined
++
++template <typename Container>
++void do_append(QVarLengthArray<SQLTCHAR> &result, const Container &c)
++{
++    result.append(reinterpret_cast<const SQLTCHAR *>(c.data()), c.size());
++}
++
++template <>
++void toSQLTCHARImpl<1>(QVarLengthArray<SQLTCHAR> &result, const QString &input)
++{
++    const auto u8 = input.toUtf8();
++    do_append(result, u8);
++}
++
++template <>
++void toSQLTCHARImpl<2>(QVarLengthArray<SQLTCHAR> &result, const QString &input)
++{
++    do_append(result, input);
++}
++
++template <>
++void toSQLTCHARImpl<4>(QVarLengthArray<SQLTCHAR> &result, const QString &input)
++{
++    const auto u32 = input.toUcs4();
++    do_append(result, u32);
++}
++
+ inline static QVarLengthArray<SQLTCHAR> toSQLTCHAR(const QString &input)
+ {
+     QVarLengthArray<SQLTCHAR> result;
+-    result.resize(input.size());
+-    switch(sizeof(SQLTCHAR)) {
+-        case 1:
+-            memcpy(result.data(), input.toUtf8().data(), input.size());
+-            break;
+-        case 2:
+-            memcpy(result.data(), input.unicode(), input.size() * 2);
+-            break;
+-        case 4:
+-            memcpy(result.data(), input.toUcs4().data(), input.size() * 4);
+-            break;
+-        default:
+-            qCritical("sizeof(SQLTCHAR) is %d. Don't know how to handle this.", int(sizeof(SQLTCHAR)));
+-    }
++    toSQLTCHARImpl(result, input);
+     result.append(0); // make sure it's null terminated, doesn't matter if it already is, it does if it isn't.
+     return result;
+ }
+@@ -763,6 +779,14 @@ QChar QODBCDriverPrivate::quoteChar()
+     return quote;
+ }
+ 
++static SQLRETURN qt_string_SQLSetConnectAttr(SQLHDBC handle, SQLINTEGER attr, const QString &val)
++{
++    auto encoded = toSQLTCHAR(val);
++    return SQLSetConnectAttr(handle, attr,
++                             encoded.data(),
++                             SQLINTEGER(encoded.size() * sizeof(SQLTCHAR))); // size in bytes
++}
++
+ 
+ bool QODBCDriverPrivate::setConnectionOptions(const QString& connOpts)
+ {
+@@ -798,10 +822,7 @@ bool QODBCDriverPrivate::setConnectionOptions(const QString& connOpts)
+             v = val.toUInt();
+             r = SQLSetConnectAttr(hDbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER) size_t(v), 0);
+         } else if (opt.toUpper() == QLatin1String("SQL_ATTR_CURRENT_CATALOG")) {
+-            val.utf16(); // 0 terminate
+-            r = SQLSetConnectAttr(hDbc, SQL_ATTR_CURRENT_CATALOG,
+-                                    toSQLTCHAR(val).data(),
+-                                    val.length()*sizeof(SQLTCHAR));
++            r = qt_string_SQLSetConnectAttr(hDbc, SQL_ATTR_CURRENT_CATALOG, val);
+         } else if (opt.toUpper() == QLatin1String("SQL_ATTR_METADATA_ID")) {
+             if (val.toUpper() == QLatin1String("SQL_TRUE")) {
+                 v = SQL_TRUE;
+@@ -816,10 +837,7 @@ bool QODBCDriverPrivate::setConnectionOptions(const QString& connOpts)
+             v = val.toUInt();
+             r = SQLSetConnectAttr(hDbc, SQL_ATTR_PACKET_SIZE, (SQLPOINTER) size_t(v), 0);
+         } else if (opt.toUpper() == QLatin1String("SQL_ATTR_TRACEFILE")) {
+-            val.utf16(); // 0 terminate
+-            r = SQLSetConnectAttr(hDbc, SQL_ATTR_TRACEFILE,
+-                                    toSQLTCHAR(val).data(),
+-                                    val.length()*sizeof(SQLTCHAR));
++            r = qt_string_SQLSetConnectAttr(hDbc, SQL_ATTR_TRACEFILE, val);
+         } else if (opt.toUpper() == QLatin1String("SQL_ATTR_TRACE")) {
+             if (val.toUpper() == QLatin1String("SQL_OPT_TRACE_OFF")) {
+                 v = SQL_OPT_TRACE_OFF;
+@@ -1022,9 +1040,12 @@ bool QODBCResult::reset (const QString& query)
+         return false;
+     }
+ 
+-    r = SQLExecDirect(d->hStmt,
+-                       toSQLTCHAR(query).data(),
+-                       (SQLINTEGER) query.length());
++    {
++        auto encoded = toSQLTCHAR(query);
++        r = SQLExecDirect(d->hStmt,
++                          encoded.data(),
++                          SQLINTEGER(encoded.size()));
++    }
+     if (r != SQL_SUCCESS && r != SQL_SUCCESS_WITH_INFO && r!= SQL_NO_DATA) {
+         setLastError(qMakeError(QCoreApplication::translate("QODBCResult",
+                      "Unable to execute statement"), QSqlError::StatementError, d));
+@@ -1371,9 +1392,12 @@ bool QODBCResult::prepare(const QString& query)
+         return false;
+     }
+ 
+-    r = SQLPrepare(d->hStmt,
+-                    toSQLTCHAR(query).data(),
+-                    (SQLINTEGER) query.length());
++    {
++        auto encoded = toSQLTCHAR(query);
++        r = SQLPrepare(d->hStmt,
++                       encoded.data(),
++                       SQLINTEGER(encoded.size()));
++    }
+ 
+     if (r != SQL_SUCCESS) {
+         setLastError(qMakeError(QCoreApplication::translate("QODBCResult",
+@@ -1401,7 +1425,7 @@ bool QODBCResult::exec()
+         SQLCloseCursor(d->hStmt);
+ 
+     QVector<QVariant>& values = boundValues();
+-    QVector<QByteArray> tmpStorage(values.count(), QByteArray()); // holds temporary buffers
++    QVector<QByteArray> tmpStorage(values.count(), QByteArray()); // targets for SQLBindParameter()
+     QVarLengthArray<SQLLEN, 32> indicators(values.count());
+     memset(indicators.data(), 0, indicators.size() * sizeof(SQLLEN));
+ 
+@@ -1580,35 +1604,36 @@ bool QODBCResult::exec()
+             case QVariant::String:
+                 if (d->unicode) {
+                     QByteArray &ba = tmpStorage[i];
+-                    QString str = val.toString();
++                    {
++                        const auto encoded = toSQLTCHAR(val.toString());
++                        ba = QByteArray(reinterpret_cast<const char *>(encoded.data()),
++                                        encoded.size() * sizeof(SQLTCHAR));
++                    }
++
+                     if (*ind != SQL_NULL_DATA)
+-                        *ind = str.length() * sizeof(SQLTCHAR);
+-                    int strSize = str.length() * sizeof(SQLTCHAR);
++                        *ind = ba.size();
+ 
+                     if (bindValueType(i) & QSql::Out) {
+-                        const QVarLengthArray<SQLTCHAR> a(toSQLTCHAR(str));
+-                        ba = QByteArray((const char *)a.constData(), a.size() * sizeof(SQLTCHAR));
+                         r = SQLBindParameter(d->hStmt,
+                                             i + 1,
+                                             qParamType[bindValueType(i) & QSql::InOut],
+                                             SQL_C_TCHAR,
+-                                            strSize > 254 ? SQL_WLONGVARCHAR : SQL_WVARCHAR,
++                                            ba.size() > 254 ? SQL_WLONGVARCHAR : SQL_WVARCHAR,
+                                             0, // god knows... don't change this!
+                                             0,
+-                                            ba.data(),
++                                            const_cast<char *>(ba.constData()), // don't detach
+                                             ba.size(),
+                                             ind);
+                         break;
+                     }
+-                    ba = QByteArray ((const char *)toSQLTCHAR(str).constData(), str.size()*sizeof(SQLTCHAR));
+                     r = SQLBindParameter(d->hStmt,
+                                           i + 1,
+                                           qParamType[bindValueType(i) & QSql::InOut],
+                                           SQL_C_TCHAR,
+-                                          strSize > 254 ? SQL_WLONGVARCHAR : SQL_WVARCHAR,
+-                                          strSize,
++                                          ba.size() > 254 ? SQL_WLONGVARCHAR : SQL_WVARCHAR,
++                                          ba.size(),
+                                           0,
+-                                          const_cast<char *>(ba.constData()),
++                                          const_cast<char *>(ba.constData()), // don't detach
+                                           ba.size(),
+                                           ind);
+                     break;
+@@ -1716,10 +1741,11 @@ bool QODBCResult::exec()
+             case QVariant::String:
+                 if (d->unicode) {
+                     if (bindValueType(i) & QSql::Out) {
+-                        const QByteArray &first = tmpStorage.at(i);
+-                        QVarLengthArray<SQLTCHAR> array;
+-                        array.append((const SQLTCHAR *)first.constData(), first.size());
+-                        values[i] = fromSQLTCHAR(array, first.size()/sizeof(SQLTCHAR));
++                        const QByteArray &bytes = tmpStorage.at(i);
++                        const auto strSize = bytes.size() / int(sizeof(SQLTCHAR));
++                        QVarLengthArray<SQLTCHAR> string(strSize);
++                        memcpy(string.data(), bytes.data(), strSize * sizeof(SQLTCHAR));
++                        values[i] = fromSQLTCHAR(string);
+                     }
+                     break;
+                 }
+@@ -1966,14 +1992,16 @@ bool QODBCDriver::open(const QString & db,
+     SQLSMALLINT cb;
+     QVarLengthArray<SQLTCHAR> connOut(1024);
+     memset(connOut.data(), 0, connOut.size() * sizeof(SQLTCHAR));
+-    r = SQLDriverConnect(d->hDbc,
+-                          NULL,
+-                          toSQLTCHAR(connQStr).data(),
+-                          (SQLSMALLINT)connQStr.length(),
+-                          connOut.data(),
+-                          1024,
+-                          &cb,
+-                          /*SQL_DRIVER_NOPROMPT*/0);
++    {
++        auto encoded = toSQLTCHAR(connQStr);
++        r = SQLDriverConnect(d->hDbc,
++                             nullptr,
++                             encoded.data(), SQLSMALLINT(encoded.size()),
++                             connOut.data(),
++                             1024,
++                             &cb,
++                             /*SQL_DRIVER_NOPROMPT*/0);
++    }
+ 
+     if (r != SQL_SUCCESS && r != SQL_SUCCESS_WITH_INFO) {
+         setLastError(qMakeError(tr("Unable to connect"), QSqlError::ConnectionError, d));
+@@ -2352,17 +2380,15 @@ QStringList QODBCDriver::tables(QSql::TableType type) const
+     if (tableType.isEmpty())
+         return tl;
+ 
+-    QString joinedTableTypeString = tableType.join(QLatin1Char(','));
++    {
++        auto joinedTableTypeString = toSQLTCHAR(tableType.join(u','));
+ 
+-    r = SQLTables(hStmt,
+-                   NULL,
+-                   0,
+-                   NULL,
+-                   0,
+-                   NULL,
+-                   0,
+-                   toSQLTCHAR(joinedTableTypeString).data(),
+-                   joinedTableTypeString.length() /* characters, not bytes */);
++        r = SQLTables(hStmt,
++                      nullptr, 0,
++                      nullptr, 0,
++                      nullptr, 0,
++                      joinedTableTypeString.data(), joinedTableTypeString.size());
++    }
+ 
+     if (r != SQL_SUCCESS)
+         qSqlWarning(QLatin1String("QODBCDriver::tables Unable to execute table list"), d);
+@@ -2436,28 +2462,30 @@ QSqlIndex QODBCDriver::primaryIndex(const QString& tablename) const
+                         SQL_ATTR_CURSOR_TYPE,
+                         (SQLPOINTER)SQL_CURSOR_FORWARD_ONLY,
+                         SQL_IS_UINTEGER);
+-    r = SQLPrimaryKeys(hStmt,
+-                        catalog.length() == 0 ? NULL : toSQLTCHAR(catalog).data(),
+-                        catalog.length(),
+-                        schema.length() == 0 ? NULL : toSQLTCHAR(schema).data(),
+-                        schema.length(),
+-                        toSQLTCHAR(table).data(),
+-                        table.length() /* in characters, not in bytes */);
++    {
++        auto c = toSQLTCHAR(catalog);
++        auto s = toSQLTCHAR(schema);
++        auto t = toSQLTCHAR(table);
++        r = SQLPrimaryKeys(hStmt,
++                           catalog.isEmpty() ? nullptr : c.data(), c.size(),
++                           schema.isEmpty()  ? nullptr : s.data(), s.size(),
++                           t.data(), t.size());
++    }
+ 
+     // if the SQLPrimaryKeys() call does not succeed (e.g the driver
+     // does not support it) - try an alternative method to get hold of
+     // the primary index (e.g MS Access and FoxPro)
+     if (r != SQL_SUCCESS) {
+-            r = SQLSpecialColumns(hStmt,
+-                        SQL_BEST_ROWID,
+-                        catalog.length() == 0 ? NULL : toSQLTCHAR(catalog).data(),
+-                        catalog.length(),
+-                        schema.length() == 0 ? NULL : toSQLTCHAR(schema).data(),
+-                        schema.length(),
+-                        toSQLTCHAR(table).data(),
+-                        table.length(),
+-                        SQL_SCOPE_CURROW,
+-                        SQL_NULLABLE);
++        auto c = toSQLTCHAR(catalog);
++        auto s = toSQLTCHAR(schema);
++        auto t = toSQLTCHAR(table);
++        r = SQLSpecialColumns(hStmt,
++                              SQL_BEST_ROWID,
++                              catalog.isEmpty() ? nullptr : c.data(), c.size(),
++                              schema.isEmpty()  ? nullptr : s.data(), s.size(),
++                              t.data(), t.size(),
++                              SQL_SCOPE_CURROW,
++                              SQL_NULLABLE);
+ 
+             if (r != SQL_SUCCESS) {
+                 qSqlWarning(QLatin1String("QODBCDriver::primaryIndex: Unable to execute primary key list"), d);
+@@ -2538,15 +2566,17 @@ QSqlRecord QODBCDriver::record(const QString& tablename) const
+                         SQL_ATTR_CURSOR_TYPE,
+                         (SQLPOINTER)SQL_CURSOR_FORWARD_ONLY,
+                         SQL_IS_UINTEGER);
+-    r =  SQLColumns(hStmt,
+-                     catalog.length() == 0 ? NULL : toSQLTCHAR(catalog).data(),
+-                     catalog.length(),
+-                     schema.length() == 0 ? NULL : toSQLTCHAR(schema).data(),
+-                     schema.length(),
+-                     toSQLTCHAR(table).data(),
+-                     table.length(),
+-                     NULL,
+-                     0);
++    {
++        auto c = toSQLTCHAR(catalog);
++        auto s = toSQLTCHAR(schema);
++        auto t = toSQLTCHAR(table);
++        r =  SQLColumns(hStmt,
++                        catalog.isEmpty() ? nullptr : c.data(), c.size(),
++                        schema.isEmpty()  ? nullptr : s.data(), s.size(),
++                        t.data(), t.size(),
++                        nullptr,
++                        0);
++    }
+     if (r != SQL_SUCCESS)
+         qSqlWarning(QLatin1String("QODBCDriver::record: Unable to execute column list"), d);
+ 
+-- 
+2.41.0
+

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -38,6 +38,7 @@ SRC_URI += "\
     file://0021-rcc-Just-dcument-file-name-without-full-path-to-redu.patch \
     file://0022-testlib-don-t-track-the-build-or-source-directories.patch \
     file://0023-Remove-unsetting-_FILE_OFFSET_BITS.patch \
+    file://0026-qsql_odbc-Patch-for-CVE-2023-24607.patch \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with


### PR DESCRIPTION
The fix for CVE-2023-24607 is not available in the GitHub qt5 and meta-qt5 repositories. This change backports that patch from 5.15.13 to ensure it doesn't affect users of the GitHub version of meta-qt5.

## Testing:
Built locally and confirmed the CVE is no longer flagged as part of cve-check.