### PR TITLE
qtbase: Support OpenSSL 3.x

### DIFF
--- a/recipes-qt/qt5/qtbase/0001-qsslsocket_openssl_symbols-Really-support-OpenSSL-3.patch
+++ b/recipes-qt/qt5/qtbase/0001-qsslsocket_openssl_symbols-Really-support-OpenSSL-3.patch
@@ -1,0 +1,105 @@
+From 8df5d7c30fe184fde7e25a4ebb2bc4994273eae4 Mon Sep 17 00:00:00 2001
+From: Mike Looijmans <mike.looijmans@topic.nl>
+Date: Fri, 4 Aug 2023 13:56:57 +0200
+Subject: [PATCH] qsslsocket_openssl_symbols: Really support OpenSSL 3.x
+
+Based on this:
+  https://gist.github.com/seyedmmousavi/b1f6681eb37f3edbe3dcabb6e89c5d43
+---
+ src/network/ssl/qsslsocket_openssl_symbols.cpp | 18 ++++++++++++++++--
+ src/network/ssl/qsslsocket_openssl_symbols_p.h | 13 +++++++++++--
+ 2 files changed, 27 insertions(+), 4 deletions(-)
+
+diff --git a/src/network/ssl/qsslsocket_openssl_symbols.cpp b/src/network/ssl/qsslsocket_openssl_symbols.cpp
+index 368e25345f..bef91f54a0 100644
+--- a/src/network/ssl/qsslsocket_openssl_symbols.cpp
++++ b/src/network/ssl/qsslsocket_openssl_symbols.cpp
+@@ -148,7 +148,6 @@ DEFINEFUNC(int, EVP_PKEY_up_ref, EVP_PKEY *a, a, return 0, return)
+ DEFINEFUNC2(EVP_PKEY_CTX *, EVP_PKEY_CTX_new, EVP_PKEY *pkey, pkey, ENGINE *e, e, return nullptr, return)
+ DEFINEFUNC(int, EVP_PKEY_param_check, EVP_PKEY_CTX *ctx, ctx, return 0, return)
+ DEFINEFUNC(void, EVP_PKEY_CTX_free, EVP_PKEY_CTX *ctx, ctx, return, return)
+-DEFINEFUNC(int, EVP_PKEY_base_id, EVP_PKEY *a, a, return NID_undef, return)
+ DEFINEFUNC(int, RSA_bits, RSA *a, a, return 0, return)
+ DEFINEFUNC(int, DSA_bits, DSA *a, a, return 0, return)
+ DEFINEFUNC(int, OPENSSL_sk_num, OPENSSL_STACK *a, a, return -1, return)
+@@ -371,7 +370,15 @@ DEFINEFUNC(const SSL_CIPHER *, SSL_get_current_cipher, SSL *a, a, return nullptr
+ DEFINEFUNC(int, SSL_version, const SSL *a, a, return 0, return)
+ DEFINEFUNC2(int, SSL_get_error, SSL *a, a, int b, b, return -1, return)
+ DEFINEFUNC(STACK_OF(X509) *, SSL_get_peer_cert_chain, SSL *a, a, return nullptr, return)
++
++#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
++DEFINEFUNC(X509 *, SSL_get1_peer_certificate, SSL *a, a, return nullptr, return)
++DEFINEFUNC(int, EVP_PKEY_get_base_id, const EVP_PKEY *pkey, pkey, return -1, return)
++#else
+ DEFINEFUNC(X509 *, SSL_get_peer_certificate, SSL *a, a, return nullptr, return)
++DEFINEFUNC(int, EVP_PKEY_base_id, EVP_PKEY *a, a, return NID_undef, return)
++#endif // OPENSSL_VERSION_MAJOR >= 3
++
+ DEFINEFUNC(long, SSL_get_verify_result, const SSL *a, a, return -1, return)
+ DEFINEFUNC(SSL *, SSL_new, SSL_CTX *a, a, return nullptr, return)
+ DEFINEFUNC(SSL_CTX *, SSL_get_SSL_CTX, SSL *a, a, return nullptr, return)
+@@ -861,7 +868,15 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(EVP_PKEY_CTX_new)
+     RESOLVEFUNC(EVP_PKEY_param_check)
+     RESOLVEFUNC(EVP_PKEY_CTX_free)
++
++#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
++    RESOLVEFUNC(SSL_get1_peer_certificate)
++    RESOLVEFUNC(EVP_PKEY_get_base_id)
++#else
++    RESOLVEFUNC(SSL_get_peer_certificate)
+     RESOLVEFUNC(EVP_PKEY_base_id)
++#endif // OPENSSL_VERSION_MAJOR >= 3
++
+     RESOLVEFUNC(RSA_bits)
+     RESOLVEFUNC(OPENSSL_sk_new_null)
+     RESOLVEFUNC(OPENSSL_sk_push)
+@@ -1100,7 +1115,6 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(SSL_version)
+     RESOLVEFUNC(SSL_get_error)
+     RESOLVEFUNC(SSL_get_peer_cert_chain)
+-    RESOLVEFUNC(SSL_get_peer_certificate)
+     RESOLVEFUNC(SSL_get_verify_result)
+     RESOLVEFUNC(SSL_new)
+     RESOLVEFUNC(SSL_get_SSL_CTX)
+diff --git a/src/network/ssl/qsslsocket_openssl_symbols_p.h b/src/network/ssl/qsslsocket_openssl_symbols_p.h
+index 95e8897a3b..417d78f32c 100644
+--- a/src/network/ssl/qsslsocket_openssl_symbols_p.h
++++ b/src/network/ssl/qsslsocket_openssl_symbols_p.h
+@@ -237,7 +237,6 @@ Q_AUTOTEST_EXPORT int q_EVP_PKEY_up_ref(EVP_PKEY *a);
+ EVP_PKEY_CTX *q_EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
+ void q_EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
+ int q_EVP_PKEY_param_check(EVP_PKEY_CTX *ctx);
+-int q_EVP_PKEY_base_id(EVP_PKEY *a);
+ int q_RSA_bits(RSA *a);
+ Q_AUTOTEST_EXPORT int q_OPENSSL_sk_num(OPENSSL_STACK *a);
+ Q_AUTOTEST_EXPORT void q_OPENSSL_sk_pop_free(OPENSSL_STACK *a, void (*b)(void *));
+@@ -383,6 +382,17 @@ const EC_GROUP* q_EC_KEY_get0_group(const EC_KEY* k);
+ int q_EC_GROUP_get_degree(const EC_GROUP* g);
+ #endif // OPENSSL_NO_EC
+ 
++// Here we have the ones that make difference between OpenSSL pre/post v3:
++#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
++X509 *q_SSL_get1_peer_certificate(SSL *a);
++#define q_SSL_get_peer_certificate q_SSL_get1_peer_certificate
++int q_EVP_PKEY_get_base_id(const EVP_PKEY *pkey);
++#define q_EVP_PKEY_base_id q_EVP_PKEY_get_base_id
++#else
++X509 *q_SSL_get_peer_certificate(SSL *a);
++int q_EVP_PKEY_base_id(EVP_PKEY *a);
++#endif // OPENSSL_VERSION_MAJOR >= 3
++
+ DSA *q_DSA_new();
+ void q_DSA_free(DSA *a);
+ X509 *q_d2i_X509(X509 **a, const unsigned char **b, long c);
+@@ -510,7 +520,6 @@ const SSL_CIPHER *q_SSL_get_current_cipher(SSL *a);
+ int q_SSL_version(const SSL *a);
+ int q_SSL_get_error(SSL *a, int b);
+ STACK_OF(X509) *q_SSL_get_peer_cert_chain(SSL *a);
+-X509 *q_SSL_get_peer_certificate(SSL *a);
+ long q_SSL_get_verify_result(const SSL *a);
+ SSL *q_SSL_new(SSL_CTX *a);
+ SSL_CTX *q_SSL_get_SSL_CTX(SSL *a);
+-- 
+2.17.1
+

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -40,6 +40,9 @@ SRC_URI += "\
     file://0023-zlib-Do-not-undefine-_FILE_OFFSET_BITS.patch \
 "
 
+# Support OpenSSL 3.x
+SRC_URI += "file://0001-qsslsocket_openssl_symbols-Really-support-OpenSSL-3.patch"
+
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with
 # next major upgrade of QT
 LTO = ""


### PR DESCRIPTION
OpenSSL 3.x support in qtbase was broken, it compiles and somewhat works, but serving HTTPS pages wouldn't really work. The cause is that some functions changed signature and/or name in the 3.x version, and the qsslsocket_openssl_symbols code did not load the correct methods.

This makes that the OpenSSL 3.x version that OE installs on the system actually works with Qt5.