### PR TITLE
python3-qt5: remove bashism from recipe

### DIFF
--- a/recipes-python/pyqt5/python3-pyqt5_5.15.9.bb
+++ b/recipes-python/pyqt5/python3-pyqt5_5.15.9.bb
@@ -47,11 +47,11 @@ do_configure:prepend() {
     cd ${S}
 
     for i in ${DISABLED_FEATURES}; do
-        extra_args+=" --disabled-feature=${i}"
+        extra_args="${extra_args} --disabled-feature=${i}"
     done
 
     for i in ${PYQT_MODULES}; do
-        extra_args+=" --enable=${i}"
+        extra_args="${extra_args} --enable=${i}"
     done
 
     sip-build \


### PR DESCRIPTION
Remove bashism to python3-pyqt5 recipe allowing it to build with systems where /bin/sh is not bash.

Closes issue #534 