### PR TITLE
QtBase QtSvg CVE updates

### DIFF
--- a/recipes-python/pyqt5/python3-pyqt5_5.15.9.bb
+++ b/recipes-python/pyqt5/python3-pyqt5_5.15.9.bb
@@ -47,11 +47,11 @@ do_configure:prepend() {
     cd ${S}
 
     for i in ${DISABLED_FEATURES}; do
-        extra_args+=" --disabled-feature=${i}"
+        extra_args="${extra_args} --disabled-feature=${i}"
     done
 
     for i in ${PYQT_MODULES}; do
-        extra_args+=" --enable=${i}"
+        extra_args="${extra_args} --enable=${i}"
     done
 
     sip-build \

--- a/recipes-qt/qt5/qtbase/CVE-2023-32762.patch
+++ b/recipes-qt/qt5/qtbase/CVE-2023-32762.patch
@@ -1,0 +1,56 @@
+From 1b736a815be0222f4b24289cf17575fc15707305 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?M=C3=A5rten=20Nordheim?= <marten.nordheim@qt.io>
+Date: Fri, 5 May 2023 11:07:26 +0200
+Subject: [PATCH] Hsts: match header names case insensitively
+
+Header field names are always considered to be case-insensitive.
+
+Pick-to: 6.5 6.5.1 6.2 5.15
+Fixes: QTBUG-113392
+Change-Id: Ifb4def4bb7f2ac070416cdc76581a769f1e52b43
+Reviewed-by: Qt CI Bot <qt_ci_bot@qt-project.org>
+Reviewed-by: Edward Welbourne <edward.welbourne@qt.io>
+Reviewed-by: Volker Hilsheimer <volker.hilsheimer@qt.io>
+
+Upstream-Status: Backport [https://github.com/qt/qtbase/commit/1b736a815be0222f4b24289cf17575fc15707305]
+CVE: CVE-2023-32762
+Signed-off-by: Vivek Kumbhar <vkumbhar@mvista.com>
+---
+ src/network/access/qhsts.cpp                 | 4 ++--
+ tests/auto/network/access/hsts/tst_qhsts.cpp | 6 ++++++
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/network/access/qhsts.cpp b/src/network/access/qhsts.cpp
+index 0cef0ad3dc..be7ef7ff58 100644
+--- a/src/network/access/qhsts.cpp
++++ b/src/network/access/qhsts.cpp
+@@ -364,8 +364,8 @@ quoted-pair    = "\" CHAR
+ bool QHstsHeaderParser::parse(const QList<QPair<QByteArray, QByteArray>> &headers)
+ {
+     for (const auto &h : headers) {
+-        // We use '==' since header name was already 'trimmed' for us:
+-        if (h.first == "Strict-Transport-Security") {
++        // We compare directly because header name was already 'trimmed' for us:
++        if (h.first.compare("Strict-Transport-Security", Qt::CaseInsensitive) == 0) {
+             header = h.second;
+             // RFC6797, 8.1:
+             //
+diff --git a/tests/auto/network/access/hsts/tst_qhsts.cpp b/tests/auto/network/access/hsts/tst_qhsts.cpp
+index d72991a2eb..c3c5f58c22 100644
+--- a/tests/auto/network/access/hsts/tst_qhsts.cpp
++++ b/tests/auto/network/access/hsts/tst_qhsts.cpp
+@@ -241,6 +241,12 @@ void tst_QHsts::testSTSHeaderParser()
+     QVERIFY(parser.expirationDate() > QDateTime::currentDateTimeUtc());
+     QVERIFY(parser.includeSubDomains());
+
++    list.pop_back();
++    list << Header("strict-transport-security", "includeSubDomains;max-age=1000");
++    QVERIFY(parser.parse(list));
++    QVERIFY(parser.expirationDate() > QDateTime::currentDateTimeUtc());
++    QVERIFY(parser.includeSubDomains());
++
+     list.pop_back();
+     // Invalid (includeSubDomains twice):
+     list << Header("Strict-Transport-Security", "max-age = 1000 ; includeSubDomains;includeSubDomains");
+--
+2.35.7

--- a/recipes-qt/qt5/qtbase/CVE-2023-32763-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/CVE-2023-32763-qtbase-5.15.diff
@@ -1,0 +1,47 @@
+--- a/src/gui/painting/qfixed_p.h
++++ b/src/gui/painting/qfixed_p.h
+@@ -54,6 +54,7 @@
+ #include <QtGui/private/qtguiglobal_p.h>
+ #include "QtCore/qdebug.h"
+ #include "QtCore/qpoint.h"
++#include <QtCore/private/qnumeric_p.h>
+ #include "QtCore/qsize.h"
+
+ QT_BEGIN_NAMESPACE
+@@ -182,6 +183,14 @@ Q_DECL_CONSTEXPR inline bool operator<(int i, const QFixed &f) { return i * 64 <
+ Q_DECL_CONSTEXPR inline bool operator>(const QFixed &f, int i) { return f.value() > i * 64; }
+ Q_DECL_CONSTEXPR inline bool operator>(int i, const QFixed &f) { return i * 64 > f.value(); }
+
++inline bool qAddOverflow(QFixed v1, QFixed v2, QFixed *r)
++{
++    int val;
++    bool result = add_overflow(v1.value(), v2.value(), &val);
++    r->setValue(val);
++    return result;
++}
++
+ #ifndef QT_NO_DEBUG_STREAM
+ inline QDebug &operator<<(QDebug &dbg, const QFixed &f)
+ { return dbg << f.toReal(); }
+
+
+--- a/src/gui/text/qtextlayout.cpp
++++ b/src/gui/text/qtextlayout.cpp
+@@ -2163,11 +2163,14 @@ found:
+         eng->maxWidth = qMax(eng->maxWidth, line.textWidth);
+     } else {
+         eng->minWidth = qMax(eng->minWidth, lbh.minw);
+-        eng->maxWidth += line.textWidth;
++        if (qAddOverflow(eng->maxWidth, line.textWidth, &eng->maxWidth))
++            eng->maxWidth = QFIXED_MAX;
+     }
+
+-    if (line.textWidth > 0 && item < eng->layoutData->items.size())
+-        eng->maxWidth += lbh.spaceData.textWidth;
++    if (line.textWidth > 0 && item < eng->layoutData->items.size()) {
++        if (qAddOverflow(eng->maxWidth, lbh.spaceData.textWidth, &eng->maxWidth))
++            eng->maxWidth = QFIXED_MAX;
++    }
+
+     line.textWidth += trailingSpace;
+     if (lbh.spaceData.length) {

--- a/recipes-qt/qt5/qtbase/CVE-2023-32763-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/CVE-2023-32763-qtbase-5.15.diff
@@ -1,3 +1,17 @@
+From 4964af998a1788eba15e0b4ab3382e1ebb709daf Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 10 Oct 2023 16:06:27 +0200
+Subject: [PATCH] qtbase: Pick CVE-2023-32763 fix
+
+CVE: CVE-2023-32763
+Upstream-Status: Backport [https://download.qt.io/official_releases/qt/5.15/CVE-2023-32763-qtbase-5.15.diff]
+---
+ src/gui/painting/qfixed_p.h  | 9 +++++++++
+ src/gui/text/qtextlayout.cpp | 9 ++++++---
+ 2 files changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/src/gui/painting/qfixed_p.h b/src/gui/painting/qfixed_p.h
+index 846592881c..57d750a4b3 100644
 --- a/src/gui/painting/qfixed_p.h
 +++ b/src/gui/painting/qfixed_p.h
 @@ -54,6 +54,7 @@
@@ -6,12 +20,12 @@
  #include "QtCore/qpoint.h"
 +#include <QtCore/private/qnumeric_p.h>
  #include "QtCore/qsize.h"
-
+ 
  QT_BEGIN_NAMESPACE
 @@ -182,6 +183,14 @@ Q_DECL_CONSTEXPR inline bool operator<(int i, const QFixed &f) { return i * 64 <
  Q_DECL_CONSTEXPR inline bool operator>(const QFixed &f, int i) { return f.value() > i * 64; }
  Q_DECL_CONSTEXPR inline bool operator>(int i, const QFixed &f) { return i * 64 > f.value(); }
-
+ 
 +inline bool qAddOverflow(QFixed v1, QFixed v2, QFixed *r)
 +{
 +    int val;
@@ -23,11 +37,11 @@
  #ifndef QT_NO_DEBUG_STREAM
  inline QDebug &operator<<(QDebug &dbg, const QFixed &f)
  { return dbg << f.toReal(); }
-
-
+diff --git a/src/gui/text/qtextlayout.cpp b/src/gui/text/qtextlayout.cpp
+index 26ac37b016..f6c69ff4a2 100644
 --- a/src/gui/text/qtextlayout.cpp
 +++ b/src/gui/text/qtextlayout.cpp
-@@ -2163,11 +2163,14 @@ found:
+@@ -2150,11 +2150,14 @@ found:
          eng->maxWidth = qMax(eng->maxWidth, line.textWidth);
      } else {
          eng->minWidth = qMax(eng->minWidth, lbh.minw);
@@ -35,13 +49,13 @@
 +        if (qAddOverflow(eng->maxWidth, line.textWidth, &eng->maxWidth))
 +            eng->maxWidth = QFIXED_MAX;
      }
-
+ 
 -    if (line.textWidth > 0 && item < eng->layoutData->items.size())
 -        eng->maxWidth += lbh.spaceData.textWidth;
 +    if (line.textWidth > 0 && item < eng->layoutData->items.size()) {
 +        if (qAddOverflow(eng->maxWidth, lbh.spaceData.textWidth, &eng->maxWidth))
 +            eng->maxWidth = QFIXED_MAX;
 +    }
-
+ 
      line.textWidth += trailingSpace;
      if (lbh.spaceData.length) {

--- a/recipes-qt/qt5/qtbase/CVE-2023-33285-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/CVE-2023-33285-qtbase-5.15.diff
@@ -1,0 +1,68 @@
+--- a/src/network/kernel/qdnslookup_unix.cpp
++++ b/src/network/kernel/qdnslookup_unix.cpp
+@@ -227,7 +227,6 @@ void QDnsLookupRunnable::query(const int requestType, const QByteArray &requestN
+     // responseLength in case of error, we still can extract the
+     // exact error code from the response.
+     HEADER *header = (HEADER*)response;
+-    const int answerCount = ntohs(header->ancount);
+     switch (header->rcode) {
+     case NOERROR:
+         break;
+@@ -260,18 +259,31 @@ void QDnsLookupRunnable::query(const int requestType, const QByteArray &requestN
+         return;
+     }
+
+-    // Skip the query host, type (2 bytes) and class (2 bytes).
+     char host[PACKETSZ], answer[PACKETSZ];
+     unsigned char *p = response + sizeof(HEADER);
+-    int status = local_dn_expand(response, response + responseLength, p, host, sizeof(host));
+-    if (status < 0) {
++    int status;
++
++    if (ntohs(header->qdcount) == 1) {
++        // Skip the query host, type (2 bytes) and class (2 bytes).
++        status = local_dn_expand(response, response + responseLength, p, host, sizeof(host));
++        if (status < 0) {
++            reply->error = QDnsLookup::InvalidReplyError;
++            reply->errorString = tr("Could not expand domain name");
++            return;
++        }
++        if ((p - response) + status + 4 >= responseLength)
++            header->qdcount = 0xffff;   // invalid reply below
++        else
++            p += status + 4;
++    }
++    if (ntohs(header->qdcount) > 1) {
+         reply->error = QDnsLookup::InvalidReplyError;
+-        reply->errorString = tr("Could not expand domain name");
++        reply->errorString = tr("Invalid reply received");
+         return;
+     }
+-    p += status + 4;
+
+     // Extract results.
++    const int answerCount = ntohs(header->ancount);
+     int answerIndex = 0;
+     while ((p < response + responseLength) && (answerIndex < answerCount)) {
+         status = local_dn_expand(response, response + responseLength, p, host, sizeof(host));
+@@ -283,6 +295,11 @@ void QDnsLookupRunnable::query(const int requestType, const QByteArray &requestN
+         const QString name = QUrl::fromAce(host);
+
+         p += status;
++
++        if ((p - response) + 10 > responseLength) {
++            // probably just a truncated reply, return what we have
++            return;
++        }
+         const quint16 type = (p[0] << 8) | p[1];
+         p += 2; // RR type
+         p += 2; // RR class
+@@ -290,6 +307,8 @@ void QDnsLookupRunnable::query(const int requestType, const QByteArray &requestN
+         p += 4;
+         const quint16 size = (p[0] << 8) | p[1];
+         p += 2;
++        if ((p - response) + size > responseLength)
++            return;             // truncated
+
+         if (type == QDnsLookup::A) {
+             if (size != 4) {

--- a/recipes-qt/qt5/qtbase/CVE-2023-33285-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/CVE-2023-33285-qtbase-5.15.diff
@@ -1,3 +1,16 @@
+From 70be54588f7227e0100d511530170b5cdb46ee5a Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 10 Oct 2023 16:08:05 +0200
+Subject: [PATCH] qtbase: Pick CVE-2023-33285 fix
+
+CVE: CVE-2023-33285
+Upstream-Status: Backport [https://download.qt.io/official_releases/qt/5.15/CVE-2023-33285-qtbase-5.15.diff]
+---
+ src/network/kernel/qdnslookup_unix.cpp | 31 +++++++++++++++++++++-----
+ 1 file changed, 25 insertions(+), 6 deletions(-)
+
+diff --git a/src/network/kernel/qdnslookup_unix.cpp b/src/network/kernel/qdnslookup_unix.cpp
+index 12b40fc35d..99e999d436 100644
 --- a/src/network/kernel/qdnslookup_unix.cpp
 +++ b/src/network/kernel/qdnslookup_unix.cpp
 @@ -227,7 +227,6 @@ void QDnsLookupRunnable::query(const int requestType, const QByteArray &requestN
@@ -11,7 +24,7 @@
 @@ -260,18 +259,31 @@ void QDnsLookupRunnable::query(const int requestType, const QByteArray &requestN
          return;
      }
-
+ 
 -    // Skip the query host, type (2 bytes) and class (2 bytes).
      char host[PACKETSZ], answer[PACKETSZ];
      unsigned char *p = response + sizeof(HEADER);
@@ -39,7 +52,7 @@
          return;
      }
 -    p += status + 4;
-
+ 
      // Extract results.
 +    const int answerCount = ntohs(header->ancount);
      int answerIndex = 0;
@@ -47,7 +60,7 @@
          status = local_dn_expand(response, response + responseLength, p, host, sizeof(host));
 @@ -283,6 +295,11 @@ void QDnsLookupRunnable::query(const int requestType, const QByteArray &requestN
          const QString name = QUrl::fromAce(host);
-
+ 
          p += status;
 +
 +        if ((p - response) + 10 > responseLength) {
@@ -63,6 +76,6 @@
          p += 2;
 +        if ((p - response) + size > responseLength)
 +            return;             // truncated
-
+ 
          if (type == QDnsLookup::A) {
              if (size != 4) {

--- a/recipes-qt/qt5/qtbase/CVE-2023-34410-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/CVE-2023-34410-qtbase-5.15.diff
@@ -1,0 +1,54 @@
+--- a/src/network/ssl/qsslsocket_schannel.cpp
++++ b/src/network/ssl/qsslsocket_schannel.cpp
+@@ -1880,6 +1880,28 @@ bool QSslSocketBackendPrivate::verifyCertContext(CERT_CONTEXT *certContext)
+     if (configuration.peerVerifyDepth > 0 && DWORD(configuration.peerVerifyDepth) < verifyDepth)
+         verifyDepth = DWORD(configuration.peerVerifyDepth);
+
++    const auto &caCertificates = q->sslConfiguration().caCertificates();
++
++    if (!rootCertOnDemandLoadingAllowed()
++            && !(chain->TrustStatus.dwErrorStatus & CERT_TRUST_IS_PARTIAL_CHAIN)
++            && (q->peerVerifyMode() == QSslSocket::VerifyPeer
++                    || (isClient && q->peerVerifyMode() == QSslSocket::AutoVerifyPeer))) {
++        // When verifying a peer Windows "helpfully" builds a chain that
++        // may include roots from the system store. But we don't want that if
++        // the user has set their own CA certificates.
++        // Since Windows claims this is not a partial chain the root is included
++        // and we have to check that it is one of our configured CAs.
++        CERT_CHAIN_ELEMENT *element = chain->rgpElement[chain->cElement - 1];
++        QSslCertificate certificate = getCertificateFromChainElement(element);
++        if (!caCertificates.contains(certificate)) {
++            auto error = QSslError(QSslError::CertificateUntrusted, certificate);
++            sslErrors += error;
++            emit q->peerVerifyError(error);
++            if (q->state() != QAbstractSocket::ConnectedState)
++                return false;
++        }
++    }
++
+     for (DWORD i = 0; i < verifyDepth; i++) {
+         CERT_CHAIN_ELEMENT *element = chain->rgpElement[i];
+         QSslCertificate certificate = getCertificateFromChainElement(element);
+
+
+--- a/src/network/ssl/qsslsocket.cpp
++++ b/src/network/ssl/qsslsocket.cpp
+@@ -2221,6 +2221,10 @@ QSslSocketPrivate::QSslSocketPrivate()
+     , flushTriggered(false)
+ {
+     QSslConfigurationPrivate::deepCopyDefaultConfiguration(&configuration);
++    // If the global configuration doesn't allow root certificates to be loaded
++    // on demand then we have to disable it for this socket as well.
++    if (!configuration.allowRootCertOnDemandLoading)
++        allowRootCertOnDemandLoading = false;
+ }
+
+ /*!
+@@ -2470,6 +2474,7 @@ void QSslConfigurationPrivate::deepCopyDefaultConfiguration(QSslConfigurationPri
+     ptr->sessionProtocol = global->sessionProtocol;
+     ptr->ciphers = global->ciphers;
+     ptr->caCertificates = global->caCertificates;
++    ptr->allowRootCertOnDemandLoading = global->allowRootCertOnDemandLoading;
+     ptr->protocol = global->protocol;
+     ptr->peerVerifyMode = global->peerVerifyMode;
+     ptr->peerVerifyDepth = global->peerVerifyDepth;

--- a/recipes-qt/qt5/qtbase/CVE-2023-34410-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/CVE-2023-34410-qtbase-5.15.diff
@@ -1,9 +1,46 @@
+From ec348cf21e3cecfda0e1d7db6f2ecf423509f55a Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 10 Oct 2023 16:09:29 +0200
+Subject: [PATCH] qtbase: Pick CVE-2023-34410 fix
+
+CVE: CVE-2023-34410
+Upstream-Status: Backport [https://download.qt.io/official_releases/qt/5.15/CVE-2023-34410-qtbase-5.15.diff]
+---
+ src/network/ssl/qsslsocket.cpp          |  5 +++++
+ src/network/ssl/qsslsocket_schannel.cpp | 22 ++++++++++++++++++++++
+ 2 files changed, 27 insertions(+)
+
+diff --git a/src/network/ssl/qsslsocket.cpp b/src/network/ssl/qsslsocket.cpp
+index 5bb6e7ee4a..2a0b3a4f1d 100644
+--- a/src/network/ssl/qsslsocket.cpp
++++ b/src/network/ssl/qsslsocket.cpp
+@@ -2221,6 +2221,10 @@ QSslSocketPrivate::QSslSocketPrivate()
+     , flushTriggered(false)
+ {
+     QSslConfigurationPrivate::deepCopyDefaultConfiguration(&configuration);
++    // If the global configuration doesn't allow root certificates to be loaded
++    // on demand then we have to disable it for this socket as well.
++    if (!configuration.allowRootCertOnDemandLoading)
++        allowRootCertOnDemandLoading = false;
+ }
+ 
+ /*!
+@@ -2470,6 +2474,7 @@ void QSslConfigurationPrivate::deepCopyDefaultConfiguration(QSslConfigurationPri
+     ptr->sessionProtocol = global->sessionProtocol;
+     ptr->ciphers = global->ciphers;
+     ptr->caCertificates = global->caCertificates;
++    ptr->allowRootCertOnDemandLoading = global->allowRootCertOnDemandLoading;
+     ptr->protocol = global->protocol;
+     ptr->peerVerifyMode = global->peerVerifyMode;
+     ptr->peerVerifyDepth = global->peerVerifyDepth;
+diff --git a/src/network/ssl/qsslsocket_schannel.cpp b/src/network/ssl/qsslsocket_schannel.cpp
+index c956ce3c2b..d1b23af29b 100644
 --- a/src/network/ssl/qsslsocket_schannel.cpp
 +++ b/src/network/ssl/qsslsocket_schannel.cpp
 @@ -1880,6 +1880,28 @@ bool QSslSocketBackendPrivate::verifyCertContext(CERT_CONTEXT *certContext)
      if (configuration.peerVerifyDepth > 0 && DWORD(configuration.peerVerifyDepth) < verifyDepth)
          verifyDepth = DWORD(configuration.peerVerifyDepth);
-
+ 
 +    const auto &caCertificates = q->sslConfiguration().caCertificates();
 +
 +    if (!rootCertOnDemandLoadingAllowed()
@@ -29,26 +66,3 @@
      for (DWORD i = 0; i < verifyDepth; i++) {
          CERT_CHAIN_ELEMENT *element = chain->rgpElement[i];
          QSslCertificate certificate = getCertificateFromChainElement(element);
-
-
---- a/src/network/ssl/qsslsocket.cpp
-+++ b/src/network/ssl/qsslsocket.cpp
-@@ -2221,6 +2221,10 @@ QSslSocketPrivate::QSslSocketPrivate()
-     , flushTriggered(false)
- {
-     QSslConfigurationPrivate::deepCopyDefaultConfiguration(&configuration);
-+    // If the global configuration doesn't allow root certificates to be loaded
-+    // on demand then we have to disable it for this socket as well.
-+    if (!configuration.allowRootCertOnDemandLoading)
-+        allowRootCertOnDemandLoading = false;
- }
-
- /*!
-@@ -2470,6 +2474,7 @@ void QSslConfigurationPrivate::deepCopyDefaultConfiguration(QSslConfigurationPri
-     ptr->sessionProtocol = global->sessionProtocol;
-     ptr->ciphers = global->ciphers;
-     ptr->caCertificates = global->caCertificates;
-+    ptr->allowRootCertOnDemandLoading = global->allowRootCertOnDemandLoading;
-     ptr->protocol = global->protocol;
-     ptr->peerVerifyMode = global->peerVerifyMode;
-     ptr->peerVerifyDepth = global->peerVerifyDepth;

--- a/recipes-qt/qt5/qtbase/CVE-2023-37369-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/CVE-2023-37369-qtbase-5.15.diff
@@ -1,0 +1,203 @@
+diff --git a/src/corelib/serialization/qxmlstream.cpp b/src/corelib/serialization/qxmlstream.cpp
+index 7cd457ba3a..11d162cb79 100644
+--- a/src/corelib/serialization/qxmlstream.cpp
++++ b/src/corelib/serialization/qxmlstream.cpp
+@@ -1302,15 +1302,18 @@ inline int QXmlStreamReaderPrivate::fastScanContentCharList()
+     return n;
+ }
+ 
+-inline int QXmlStreamReaderPrivate::fastScanName(int *prefix)
++// Fast scan an XML attribute name (e.g. "xml:lang").
++inline QXmlStreamReaderPrivate::FastScanNameResult
++QXmlStreamReaderPrivate::fastScanName(Value *val)
+ {
+     int n = 0;
+     uint c;
+     while ((c = getChar()) != StreamEOF) {
+         if (n >= 4096) {
+             // This is too long to be a sensible name, and
+-            // can exhaust memory
+-            return 0;
++            // can exhaust memory, or the range of decltype(*prefix)
++            raiseNamePrefixTooLongError();
++            return {};
+         }
+         switch (c) {
+         case '\n':
+@@ -1339,23 +1342,23 @@ inline int QXmlStreamReaderPrivate::fastScanName(int *prefix)
+         case '+':
+         case '*':
+             putChar(c);
+-            if (prefix && *prefix == n+1) {
+-                *prefix = 0;
++            if (val && val->prefix == n + 1) {
++                val->prefix = 0;
+                 putChar(':');
+                 --n;
+             }
+-            return n;
++            return FastScanNameResult(n);
+         case ':':
+-            if (prefix) {
+-                if (*prefix == 0) {
+-                    *prefix = n+2;
++            if (val) {
++                if (val->prefix == 0) {
++                    val->prefix = n + 2;
+                 } else { // only one colon allowed according to the namespace spec.
+                     putChar(c);
+-                    return n;
++                    return FastScanNameResult(n);
+                 }
+             } else {
+                 putChar(c);
+-                return n;
++                return FastScanNameResult(n);
+             }
+             Q_FALLTHROUGH();
+         default:
+@@ -1364,12 +1367,12 @@ inline int QXmlStreamReaderPrivate::fastScanName(int *prefix)
+         }
+     }
+ 
+-    if (prefix)
+-        *prefix = 0;
++    if (val)
++        val->prefix = 0;
+     int pos = textBuffer.size() - n;
+     putString(textBuffer, pos);
+     textBuffer.resize(pos);
+-    return 0;
++    return FastScanNameResult(0);
+ }
+ 
+ enum NameChar { NameBeginning, NameNotBeginning, NotName };
+@@ -1878,6 +1881,14 @@ void QXmlStreamReaderPrivate::raiseWellFormedError(const QString &message)
+     raiseError(QXmlStreamReader::NotWellFormedError, message);
+ }
+ 
++void QXmlStreamReaderPrivate::raiseNamePrefixTooLongError()
++{
++    // TODO: add a ImplementationLimitsExceededError and use it instead
++    raiseError(QXmlStreamReader::NotWellFormedError,
++               QXmlStream::tr("Length of XML attribute name exceeds implemnetation limits (4KiB "
++                              "characters)."));
++}
++
+ void QXmlStreamReaderPrivate::parseError()
+ {
+ 
+diff --git a/src/corelib/serialization/qxmlstream.g b/src/corelib/serialization/qxmlstream.g
+index 4321fed68a..8c6a1a5887 100644
+--- a/src/corelib/serialization/qxmlstream.g
++++ b/src/corelib/serialization/qxmlstream.g
+@@ -516,7 +516,16 @@ public:
+     int fastScanLiteralContent();
+     int fastScanSpace();
+     int fastScanContentCharList();
+-    int fastScanName(int *prefix = nullptr);
++
++    struct FastScanNameResult {
++        FastScanNameResult() : ok(false) {}
++        explicit FastScanNameResult(int len) : addToLen(len), ok(true) { }
++        operator bool() { return ok; }
++        int operator*() { Q_ASSERT(ok); return addToLen; }
++        int addToLen;
++        bool ok;
++    };
++    FastScanNameResult fastScanName(Value *val = nullptr);
+     inline int fastScanNMTOKEN();
+ 
+ 
+@@ -525,6 +534,7 @@ public:
+ 
+     void raiseError(QXmlStreamReader::Error error, const QString& message = QString());
+     void raiseWellFormedError(const QString &message);
++    void raiseNamePrefixTooLongError();
+ 
+     QXmlStreamEntityResolver *entityResolver;
+ 
+@@ -1811,7 +1821,12 @@ space_opt ::= space;
+ qname ::= LETTER;
+ /.
+         case $rule_number: {
+-            sym(1).len += fastScanName(&sym(1).prefix);
++            Value &val = sym(1);
++            if (auto res = fastScanName(&val))
++                val.len += *res;
++            else
++                return false;
++
+             if (atEnd) {
+                 resume($rule_number);
+                 return false;
+@@ -1822,7 +1837,11 @@ qname ::= LETTER;
+ name ::= LETTER;
+ /.
+         case $rule_number:
+-            sym(1).len += fastScanName();
++            if (auto res = fastScanName())
++                sym(1).len += *res;
++            else
++                return false;
++
+             if (atEnd) {
+                 resume($rule_number);
+                 return false;
+diff --git a/src/corelib/serialization/qxmlstream_p.h b/src/corelib/serialization/qxmlstream_p.h
+index e5bde7b98e..b01484cac3 100644
+--- a/src/corelib/serialization/qxmlstream_p.h
++++ b/src/corelib/serialization/qxmlstream_p.h
+@@ -1005,7 +1005,16 @@ public:
+     int fastScanLiteralContent();
+     int fastScanSpace();
+     int fastScanContentCharList();
+-    int fastScanName(int *prefix = nullptr);
++
++    struct FastScanNameResult {
++        FastScanNameResult() : ok(false) {}
++        explicit FastScanNameResult(int len) : addToLen(len), ok(true) { }
++        operator bool() { return ok; }
++        int operator*() { Q_ASSERT(ok); return addToLen; }
++        int addToLen;
++        bool ok;
++    };
++    FastScanNameResult fastScanName(Value *val = nullptr);
+     inline int fastScanNMTOKEN();
+ 
+ 
+@@ -1014,6 +1023,7 @@ public:
+ 
+     void raiseError(QXmlStreamReader::Error error, const QString& message = QString());
+     void raiseWellFormedError(const QString &message);
++    void raiseNamePrefixTooLongError();
+ 
+     QXmlStreamEntityResolver *entityResolver;
+ 
+@@ -1939,7 +1949,12 @@ bool QXmlStreamReaderPrivate::parse()
+         break;
+ 
+         case 262: {
+-            sym(1).len += fastScanName(&sym(1).prefix);
++            Value &val = sym(1);
++            if (auto res = fastScanName(&val))
++                val.len += *res;
++            else
++                return false;
++
+             if (atEnd) {
+                 resume(262);
+                 return false;
+@@ -1947,7 +1962,11 @@ bool QXmlStreamReaderPrivate::parse()
+         } break;
+ 
+         case 263:
+-            sym(1).len += fastScanName();
++            if (auto res = fastScanName())
++                sym(1).len += *res;
++            else
++                return false;
++
+             if (atEnd) {
+                 resume(263);
+                 return false;

--- a/recipes-qt/qt5/qtbase/CVE-2023-37369-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/CVE-2023-37369-qtbase-5.15.diff
@@ -1,5 +1,18 @@
+From 8b7ecba1bab3a02af1c5d5b2278b88e931e612e6 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 10 Oct 2023 16:10:40 +0200
+Subject: [PATCH] qtbase: Pick CVE-2023-37369 fix
+
+CVE: CVE-2023-37369
+Upstream-Status: Backport [https://download.qt.io/official_releases/qt/5.15/CVE-2023-37369-qtbase-5.15.diff]
+---
+ src/corelib/serialization/qxmlstream.cpp | 39 +++++++++++++++---------
+ src/corelib/serialization/qxmlstream.g   | 25 +++++++++++++--
+ src/corelib/serialization/qxmlstream_p.h | 25 +++++++++++++--
+ 3 files changed, 69 insertions(+), 20 deletions(-)
+
 diff --git a/src/corelib/serialization/qxmlstream.cpp b/src/corelib/serialization/qxmlstream.cpp
-index 7cd457ba3a..11d162cb79 100644
+index b2f846544d..6c98e7c013 100644
 --- a/src/corelib/serialization/qxmlstream.cpp
 +++ b/src/corelib/serialization/qxmlstream.cpp
 @@ -1302,15 +1302,18 @@ inline int QXmlStreamReaderPrivate::fastScanContentCharList()
@@ -88,7 +101,7 @@ index 7cd457ba3a..11d162cb79 100644
  {
  
 diff --git a/src/corelib/serialization/qxmlstream.g b/src/corelib/serialization/qxmlstream.g
-index 4321fed68a..8c6a1a5887 100644
+index b623de9505..e431028506 100644
 --- a/src/corelib/serialization/qxmlstream.g
 +++ b/src/corelib/serialization/qxmlstream.g
 @@ -516,7 +516,16 @@ public:
@@ -117,7 +130,7 @@ index 4321fed68a..8c6a1a5887 100644
  
      QXmlStreamEntityResolver *entityResolver;
  
-@@ -1811,7 +1821,12 @@ space_opt ::= space;
+@@ -1809,7 +1819,12 @@ space_opt ::= space;
  qname ::= LETTER;
  /.
          case $rule_number: {
@@ -131,7 +144,7 @@ index 4321fed68a..8c6a1a5887 100644
              if (atEnd) {
                  resume($rule_number);
                  return false;
-@@ -1822,7 +1837,11 @@ qname ::= LETTER;
+@@ -1820,7 +1835,11 @@ qname ::= LETTER;
  name ::= LETTER;
  /.
          case $rule_number:
@@ -145,7 +158,7 @@ index 4321fed68a..8c6a1a5887 100644
                  resume($rule_number);
                  return false;
 diff --git a/src/corelib/serialization/qxmlstream_p.h b/src/corelib/serialization/qxmlstream_p.h
-index e5bde7b98e..b01484cac3 100644
+index 103b123b10..80e7f74080 100644
 --- a/src/corelib/serialization/qxmlstream_p.h
 +++ b/src/corelib/serialization/qxmlstream_p.h
 @@ -1005,7 +1005,16 @@ public:
@@ -174,7 +187,7 @@ index e5bde7b98e..b01484cac3 100644
  
      QXmlStreamEntityResolver *entityResolver;
  
-@@ -1939,7 +1949,12 @@ bool QXmlStreamReaderPrivate::parse()
+@@ -1937,7 +1947,12 @@ bool QXmlStreamReaderPrivate::parse()
          break;
  
          case 262: {
@@ -188,7 +201,7 @@ index e5bde7b98e..b01484cac3 100644
              if (atEnd) {
                  resume(262);
                  return false;
-@@ -1947,7 +1962,11 @@ bool QXmlStreamReaderPrivate::parse()
+@@ -1945,7 +1960,11 @@ bool QXmlStreamReaderPrivate::parse()
          } break;
  
          case 263:

--- a/recipes-qt/qt5/qtbase/CVE-2023-38197-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/CVE-2023-38197-qtbase-5.15.diff
@@ -1,0 +1,219 @@
+diff --git a/src/corelib/serialization/qxmlstream.cpp b/src/corelib/serialization/qxmlstream.cpp
+index bf8a2a9..6ab5d49 100644
+--- a/src/corelib/serialization/qxmlstream.cpp
++++ b/src/corelib/serialization/qxmlstream.cpp
+@@ -160,7 +160,7 @@
+     addData() or by waiting for it to arrive on the device().
+ 
+     \value UnexpectedElementError The parser encountered an element
+-    that was different to those it expected.
++    or token that was different to those it expected.
+ 
+ */
+ 
+@@ -295,13 +295,34 @@
+ 
+   QXmlStreamReader is a well-formed XML 1.0 parser that does \e not
+   include external parsed entities. As long as no error occurs, the
+-  application code can thus be assured that the data provided by the
+-  stream reader satisfies the W3C's criteria for well-formed XML. For
+-  example, you can be certain that all tags are indeed nested and
+-  closed properly, that references to internal entities have been
+-  replaced with the correct replacement text, and that attributes have
+-  been normalized or added according to the internal subset of the
+-  DTD.
++  application code can thus be assured, that
++  \list
++  \li the data provided by the stream reader satisfies the W3C's
++      criteria for well-formed XML,
++  \li tokens are provided in a valid order.
++  \endlist
++
++  Unless QXmlStreamReader raises an error, it guarantees the following:
++  \list
++  \li All tags are nested and closed properly.
++  \li References to internal entities have been replaced with the
++      correct replacement text.
++  \li Attributes have been normalized or added according to the
++      internal subset of the \l DTD.
++  \li Tokens of type \l StartDocument happen before all others,
++      aside from comments and processing instructions.
++  \li At most one DOCTYPE element (a token of type \l DTD) is present.
++  \li If present, the DOCTYPE appears before all other elements,
++      aside from StartDocument, comments and processing instructions.
++  \endlist
++
++  In particular, once any token of type \l StartElement, \l EndElement,
++  \l Characters, \l EntityReference or \l EndDocument is seen, no
++  tokens of type StartDocument or DTD will be seen. If one is present in
++  the input stream, out of order, an error is raised.
++
++  \note The token types \l Comment and \l ProcessingInstruction may appear
++  anywhere in the stream.
+ 
+   If an error occurs while parsing, atEnd() and hasError() return
+   true, and error() returns the error that occurred. The functions
+@@ -620,6 +641,7 @@
+         d->token = -1;
+         return readNext();
+     }
++    d->checkToken();
+     return d->type;
+ }
+ 
+@@ -740,6 +762,14 @@
+ };
+ 
+ 
++static const char QXmlStreamReader_XmlContextString[] =
++    "Prolog\0"
++    "Body\0";
++
++static const short QXmlStreamReader_XmlContextString_indices[] = {
++    0, 7
++};
++
+ /*!
+     \property  QXmlStreamReader::namespaceProcessing
+     The namespace-processing flag of the stream reader
+@@ -775,6 +805,16 @@
+                          QXmlStreamReader_tokenTypeString_indices[d->type]);
+ }
+ 
++/*!
++   \internal
++   \return \param ctxt (Prolog/Body) as a string.
++ */
++QString contextString(QXmlStreamReaderPrivate::XmlContext ctxt)
++{
++    return QLatin1String(QXmlStreamReader_XmlContextString +
++                         QXmlStreamReader_XmlContextString_indices[static_cast<int>(ctxt)]);
++}
++
+ #endif // QT_NO_XMLSTREAMREADER
+ 
+ QXmlStreamPrivateTagStack::QXmlStreamPrivateTagStack()
+@@ -866,6 +906,8 @@
+ 
+     type = QXmlStreamReader::NoToken;
+     error = QXmlStreamReader::NoError;
++    currentContext = XmlContext::Prolog;
++    foundDTD = false;
+ }
+ 
+ /*
+@@ -4061,6 +4103,92 @@
+     }
+ }
+ 
++static bool isTokenAllowedInContext(QXmlStreamReader::TokenType type,
++                                               QXmlStreamReaderPrivate::XmlContext loc)
++{
++    switch (type) {
++    case QXmlStreamReader::StartDocument:
++    case QXmlStreamReader::DTD:
++        return loc == QXmlStreamReaderPrivate::XmlContext::Prolog;
++
++    case QXmlStreamReader::StartElement:
++    case QXmlStreamReader::EndElement:
++    case QXmlStreamReader::Characters:
++    case QXmlStreamReader::EntityReference:
++    case QXmlStreamReader::EndDocument:
++        return loc == QXmlStreamReaderPrivate::XmlContext::Body;
++
++    case QXmlStreamReader::Comment:
++    case QXmlStreamReader::ProcessingInstruction:
++        return true;
++
++    case QXmlStreamReader::NoToken:
++    case QXmlStreamReader::Invalid:
++        return false;
++    default:
++        return false;
++    }
++}
++
++/*!
++   \internal
++   \brief QXmlStreamReader::isValidToken
++   \return \c true if \param type is a valid token type.
++   \return \c false if \param type is an unexpected token,
++   which indicates a non-well-formed or invalid XML stream.
++ */
++bool QXmlStreamReaderPrivate::isValidToken(QXmlStreamReader::TokenType type)
++{
++    // Don't change currentContext, if Invalid or NoToken occur in the prolog
++    if (type == QXmlStreamReader::Invalid || type == QXmlStreamReader::NoToken)
++        return false;
++
++    // If a token type gets rejected in the body, there is no recovery
++    const bool result = isTokenAllowedInContext(type, currentContext);
++    if (result || currentContext == XmlContext::Body)
++        return result;
++
++    // First non-Prolog token observed => switch context to body and check again.
++    currentContext = XmlContext::Body;
++    return isTokenAllowedInContext(type, currentContext);
++}
++
++/*!
++   \internal
++   Checks token type and raises an error, if it is invalid
++   in the current context (prolog/body).
++ */
++void QXmlStreamReaderPrivate::checkToken()
++{
++    Q_Q(QXmlStreamReader);
++
++    // The token type must be consumed, to keep track if the body has been reached.
++    const XmlContext context = currentContext;
++    const bool ok = isValidToken(type);
++
++    // Do nothing if an error has been raised already (going along with an unexpected token)
++    if (error != QXmlStreamReader::Error::NoError)
++        return;
++
++    if (!ok) {
++        raiseError(QXmlStreamReader::UnexpectedElementError,
++                   QLatin1String("Unexpected token type %1 in %2.")
++                   .arg(q->tokenString(), contextString(context)));
++        return;
++    }
++
++    if (type != QXmlStreamReader::DTD)
++        return;
++
++    // Raise error on multiple DTD tokens
++    if (foundDTD) {
++        raiseError(QXmlStreamReader::UnexpectedElementError,
++                   QLatin1String("Found second DTD token in %1.").arg(contextString(context)));
++    } else {
++        foundDTD = true;
++    }
++}
++
+ /*!
+  \fn bool QXmlStreamAttributes::hasAttribute(const QString &qualifiedName) const
+  \since 4.5
+diff --git a/src/corelib/serialization/qxmlstream_p.h b/src/corelib/serialization/qxmlstream_p.h
+index 8f7c9e0..708059b 100644
+--- a/src/corelib/serialization/qxmlstream_p.h
++++ b/src/corelib/serialization/qxmlstream_p.h
+@@ -804,6 +804,17 @@
+ #endif
+     bool atEnd;
+ 
++    enum class XmlContext
++    {
++        Prolog,
++        Body,
++    };
++
++    XmlContext currentContext = XmlContext::Prolog;
++    bool foundDTD = false;
++    bool isValidToken(QXmlStreamReader::TokenType type);
++    void checkToken();
++
+     /*!
+       \sa setType()
+      */

--- a/recipes-qt/qt5/qtbase/CVE-2023-38197-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/CVE-2023-38197-qtbase-5.15.diff
@@ -1,8 +1,20 @@
+From ae3946f38904b626a73a64f2829f60c911e2943b Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 10 Oct 2023 16:11:57 +0200
+Subject: [PATCH] qtbase: Pick CVE-2023-38197 fix
+
+CVE: CVE-2023-38197
+Upstream-Status: Backport [https://download.qt.io/official_releases/qt/5.15/CVE-2023-38197-qtbase-5.15.diff]
+---
+ src/corelib/serialization/qxmlstream.cpp | 144 +++++++++++++++++++++--
+ src/corelib/serialization/qxmlstream_p.h |  11 ++
+ 2 files changed, 147 insertions(+), 8 deletions(-)
+
 diff --git a/src/corelib/serialization/qxmlstream.cpp b/src/corelib/serialization/qxmlstream.cpp
-index bf8a2a9..6ab5d49 100644
+index 6c98e7c013..2553d3e09a 100644
 --- a/src/corelib/serialization/qxmlstream.cpp
 +++ b/src/corelib/serialization/qxmlstream.cpp
-@@ -160,7 +160,7 @@
+@@ -160,7 +160,7 @@ enum { StreamEOF = ~0U };
      addData() or by waiting for it to arrive on the device().
  
      \value UnexpectedElementError The parser encountered an element
@@ -11,7 +23,7 @@ index bf8a2a9..6ab5d49 100644
  
  */
  
-@@ -295,13 +295,34 @@
+@@ -295,13 +295,34 @@ QXmlStreamEntityResolver *QXmlStreamReader::entityResolver() const
  
    QXmlStreamReader is a well-formed XML 1.0 parser that does \e not
    include external parsed entities. As long as no error occurs, the
@@ -53,7 +65,7 @@ index bf8a2a9..6ab5d49 100644
  
    If an error occurs while parsing, atEnd() and hasError() return
    true, and error() returns the error that occurred. The functions
-@@ -620,6 +641,7 @@
+@@ -620,6 +641,7 @@ QXmlStreamReader::TokenType QXmlStreamReader::readNext()
          d->token = -1;
          return readNext();
      }
@@ -61,7 +73,7 @@ index bf8a2a9..6ab5d49 100644
      return d->type;
  }
  
-@@ -740,6 +762,14 @@
+@@ -740,6 +762,14 @@ static const short QXmlStreamReader_tokenTypeString_indices[] = {
  };
  
  
@@ -76,7 +88,7 @@ index bf8a2a9..6ab5d49 100644
  /*!
      \property  QXmlStreamReader::namespaceProcessing
      The namespace-processing flag of the stream reader
-@@ -775,6 +805,16 @@
+@@ -775,6 +805,16 @@ QString QXmlStreamReader::tokenString() const
                           QXmlStreamReader_tokenTypeString_indices[d->type]);
  }
  
@@ -93,7 +105,7 @@ index bf8a2a9..6ab5d49 100644
  #endif // QT_NO_XMLSTREAMREADER
  
  QXmlStreamPrivateTagStack::QXmlStreamPrivateTagStack()
-@@ -866,6 +906,8 @@
+@@ -866,6 +906,8 @@ void QXmlStreamReaderPrivate::init()
  
      type = QXmlStreamReader::NoToken;
      error = QXmlStreamReader::NoError;
@@ -102,7 +114,7 @@ index bf8a2a9..6ab5d49 100644
  }
  
  /*
-@@ -4061,6 +4103,92 @@
+@@ -4061,6 +4103,92 @@ void QXmlStreamWriter::writeCurrentToken(const QXmlStreamReader &reader)
      }
  }
  
@@ -196,10 +208,10 @@ index bf8a2a9..6ab5d49 100644
   \fn bool QXmlStreamAttributes::hasAttribute(const QString &qualifiedName) const
   \since 4.5
 diff --git a/src/corelib/serialization/qxmlstream_p.h b/src/corelib/serialization/qxmlstream_p.h
-index 8f7c9e0..708059b 100644
+index 80e7f74080..6db58386db 100644
 --- a/src/corelib/serialization/qxmlstream_p.h
 +++ b/src/corelib/serialization/qxmlstream_p.h
-@@ -804,6 +804,17 @@
+@@ -804,6 +804,17 @@ public:
  #endif
      bool atEnd;
  

--- a/recipes-qt/qt5/qtbase/CVE-2023-43114-5.15.patch
+++ b/recipes-qt/qt5/qtbase/CVE-2023-43114-5.15.patch
@@ -1,0 +1,120 @@
+diff --git a/src/platformsupport/fontdatabases/windows/qwindowsfontdatabase.cpp b/src/platformsupport/fontdatabases/windows/qwindowsfontdatabase.cpp
+index ba683cf686..217a968c64 100644
+--- a/src/platformsupport/fontdatabases/windows/qwindowsfontdatabase.cpp
++++ b/src/platformsupport/fontdatabases/windows/qwindowsfontdatabase.cpp
+@@ -1471,36 +1471,70 @@ QT_WARNING_POP
+     return fontEngine;
+ }
+ 
+-static QList<quint32> getTrueTypeFontOffsets(const uchar *fontData)
++static QList<quint32> getTrueTypeFontOffsets(const uchar *fontData, const uchar *fileEndSentinel)
+ {
+     QList<quint32> offsets;
+-    const quint32 headerTag = *reinterpret_cast<const quint32 *>(fontData);
++    if (fileEndSentinel - fontData < 12) {
++        qCWarning(lcQpaFonts) << "Corrupted font data detected";
++        return offsets;
++    }
++
++    const quint32 headerTag = qFromUnaligned<quint32>(fontData);
+     if (headerTag != MAKE_TAG('t', 't', 'c', 'f')) {
+         if (headerTag != MAKE_TAG(0, 1, 0, 0)
+             && headerTag != MAKE_TAG('O', 'T', 'T', 'O')
+             && headerTag != MAKE_TAG('t', 'r', 'u', 'e')
+-            && headerTag != MAKE_TAG('t', 'y', 'p', '1'))
++            && headerTag != MAKE_TAG('t', 'y', 'p', '1')) {
+             return offsets;
++        }
+         offsets << 0;
+         return offsets;
+     }
++
++    const quint32 maximumNumFonts = 0xffff;
+     const quint32 numFonts = qFromBigEndian<quint32>(fontData + 8);
+-    for (uint i = 0; i < numFonts; ++i) {
+-        offsets << qFromBigEndian<quint32>(fontData + 12 + i * 4);
++    if (numFonts > maximumNumFonts) {
++        qCWarning(lcQpaFonts) << "Font collection of" << numFonts << "fonts is too large. Aborting.";
++        return offsets;
+     }
++
++    if (quintptr(fileEndSentinel - fontData) > 12 + (numFonts - 1) * 4) {
++        for (quint32 i = 0; i < numFonts; ++i)
++            offsets << qFromBigEndian<quint32>(fontData + 12 + i * 4);
++    } else {
++        qCWarning(lcQpaFonts) << "Corrupted font data detected";
++    }
++
+     return offsets;
+ }
+ 
+-static void getFontTable(const uchar *fileBegin, const uchar *data, quint32 tag, const uchar **table, quint32 *length)
++static void getFontTable(const uchar *fileBegin, const uchar *fileEndSentinel, const uchar *data, quint32 tag, const uchar **table, quint32 *length)
+ {
+-    const quint16 numTables = qFromBigEndian<quint16>(data + 4);
+-    for (uint i = 0; i < numTables; ++i) {
+-        const quint32 offset = 12 + 16 * i;
+-        if (*reinterpret_cast<const quint32 *>(data + offset) == tag) {
+-            *table = fileBegin + qFromBigEndian<quint32>(data + offset + 8);
+-            *length = qFromBigEndian<quint32>(data + offset + 12);
+-            return;
++    if (fileEndSentinel - data >= 6) {
++        const quint16 numTables = qFromBigEndian<quint16>(data + 4);
++        if (fileEndSentinel - data >= 28 + 16 * (numTables - 1)) {
++            for (quint32 i = 0; i < numTables; ++i) {
++                const quint32 offset = 12 + 16 * i;
++                if (qFromUnaligned<quint32>(data + offset) == tag) {
++                    const quint32 tableOffset = qFromBigEndian<quint32>(data + offset + 8);
++                    if (quintptr(fileEndSentinel - fileBegin) <= tableOffset) {
++                        qCWarning(lcQpaFonts) << "Corrupted font data detected";
++                        break;
++                    }
++                    *table = fileBegin + tableOffset;
++                    *length = qFromBigEndian<quint32>(data + offset + 12);
++                    if (quintptr(fileEndSentinel - *table) < *length) {
++                        qCWarning(lcQpaFonts) << "Corrupted font data detected";
++                        break;
++                    }
++                    return;
++                }
++            }
++        } else {
++            qCWarning(lcQpaFonts) << "Corrupted font data detected";
+         }
++    } else {
++        qCWarning(lcQpaFonts) << "Corrupted font data detected";
+     }
+     *table = 0;
+     *length = 0;
+@@ -1513,8 +1547,9 @@ static void getFamiliesAndSignatures(const QByteArray &fontData,
+                                      QVector<QFontValues> *values)
+ {
+     const uchar *data = reinterpret_cast<const uchar *>(fontData.constData());
++    const uchar *dataEndSentinel = data + fontData.size();
+ 
+-    QList<quint32> offsets = getTrueTypeFontOffsets(data);
++    QList<quint32> offsets = getTrueTypeFontOffsets(data, dataEndSentinel);
+     if (offsets.isEmpty())
+         return;
+ 
+@@ -1522,7 +1557,7 @@ static void getFamiliesAndSignatures(const QByteArray &fontData,
+         const uchar *font = data + offsets.at(i);
+         const uchar *table;
+         quint32 length;
+-        getFontTable(data, font, MAKE_TAG('n', 'a', 'm', 'e'), &table, &length);
++        getFontTable(data, dataEndSentinel, font, MAKE_TAG('n', 'a', 'm', 'e'), &table, &length);
+         if (!table)
+             continue;
+         QFontNames names = qt_getCanonicalFontNames(table, length);
+@@ -1532,7 +1567,7 @@ static void getFamiliesAndSignatures(const QByteArray &fontData,
+         families->append(std::move(names));
+ 
+         if (values || signatures)
+-            getFontTable(data, font, MAKE_TAG('O', 'S', '/', '2'), &table, &length);
++            getFontTable(data, dataEndSentinel, font, MAKE_TAG('O', 'S', '/', '2'), &table, &length);
+ 
+         if (values) {
+             QFontValues fontValues;
+-- 
+2.27.0.windows.1
+

--- a/recipes-qt/qt5/qtbase/CVE-2023-43114-5.15.patch
+++ b/recipes-qt/qt5/qtbase/CVE-2023-43114-5.15.patch
@@ -1,5 +1,16 @@
+From 7ec5e6dff1d6f6b2f3abcb1a2802f174ac189d9e Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 10 Oct 2023 16:13:57 +0200
+Subject: [PATCH] qtbase: Pick CVE-2023-43114 fix
+
+CVE: CVE-2023-43114
+Upstream-Status: Backport [https://download.qt.io/official_releases/qt/5.15/CVE-2023-43114-5.15.patch]
+---
+ .../windows/qwindowsfontdatabase.cpp          | 67 ++++++++++++++-----
+ 1 file changed, 51 insertions(+), 16 deletions(-)
+
 diff --git a/src/platformsupport/fontdatabases/windows/qwindowsfontdatabase.cpp b/src/platformsupport/fontdatabases/windows/qwindowsfontdatabase.cpp
-index ba683cf686..217a968c64 100644
+index 09d2d916fe..0e6fe5eb84 100644
 --- a/src/platformsupport/fontdatabases/windows/qwindowsfontdatabase.cpp
 +++ b/src/platformsupport/fontdatabases/windows/qwindowsfontdatabase.cpp
 @@ -1471,36 +1471,70 @@ QT_WARNING_POP
@@ -115,6 +126,3 @@ index ba683cf686..217a968c64 100644
  
          if (values) {
              QFontValues fontValues;
--- 
-2.27.0.windows.1
-

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -44,6 +44,7 @@ SRC_URI += "\
     file://CVE-2023-33285-qtbase-5.15.diff \
     file://CVE-2023-34410-qtbase-5.15.diff \
     file://CVE-2023-37369-qtbase-5.15.diff \
+    file://CVE-2023-38197-qtbase-5.15.diff \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -40,6 +40,7 @@ SRC_URI += "\
     file://0023-Remove-unsetting-_FILE_OFFSET_BITS.patch \
     file://0026-qsql_odbc-Patch-for-CVE-2023-24607.patch \
     file://CVE-2023-32762.patch \
+    file://CVE-2023-32763-qtbase-5.15.diff \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -122,7 +122,7 @@ PACKAGECONFIG[xcb] = "-xcb -xcb-xlib -no-bundled-xcb-xinput -DUSE_X11=ON,-no-xcb
 PACKAGECONFIG[sql-ibase] = "-sql-ibase,-no-sql-ibase"
 PACKAGECONFIG[sql-mysql] = "-sql-mysql -mysql_config ${STAGING_BINDIR_CROSS}/mysql_config,-no-sql-mysql,mysql5"
 PACKAGECONFIG[sql-psql] = "-sql-psql,-no-sql-psql,postgresql"
-PACKAGECONFIG[sql-odbc] = "-sql-odbc,-no-sql-odbc"
+PACKAGECONFIG[sql-odbc] = "-sql-odbc,-no-sql-odbc,unixodbc"
 PACKAGECONFIG[sql-oci] = "-sql-oci,-no-sql-oci"
 PACKAGECONFIG[sql-tds] = "-sql-tds,-no-sql-tds"
 PACKAGECONFIG[sql-db2] = "-sql-db2,-no-sql-db2"

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -45,6 +45,7 @@ SRC_URI += "\
     file://CVE-2023-34410-qtbase-5.15.diff \
     file://CVE-2023-37369-qtbase-5.15.diff \
     file://CVE-2023-38197-qtbase-5.15.diff \
+    file://CVE-2023-43114-5.15.patch \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -43,6 +43,7 @@ SRC_URI += "\
     file://CVE-2023-32763-qtbase-5.15.diff \
     file://CVE-2023-33285-qtbase-5.15.diff \
     file://CVE-2023-34410-qtbase-5.15.diff \
+    file://CVE-2023-37369-qtbase-5.15.diff \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -42,6 +42,7 @@ SRC_URI += "\
     file://CVE-2023-32762.patch \
     file://CVE-2023-32763-qtbase-5.15.diff \
     file://CVE-2023-33285-qtbase-5.15.diff \
+    file://CVE-2023-34410-qtbase-5.15.diff \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -41,6 +41,7 @@ SRC_URI += "\
     file://0026-qsql_odbc-Patch-for-CVE-2023-24607.patch \
     file://CVE-2023-32762.patch \
     file://CVE-2023-32763-qtbase-5.15.diff \
+    file://CVE-2023-33285-qtbase-5.15.diff \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -39,6 +39,7 @@ SRC_URI += "\
     file://0022-testlib-don-t-track-the-build-or-source-directories.patch \
     file://0023-Remove-unsetting-_FILE_OFFSET_BITS.patch \
     file://0026-qsql_odbc-Patch-for-CVE-2023-24607.patch \
+    file://CVE-2023-32762.patch \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with

--- a/recipes-qt/qt5/qtsvg/CVE-2023-32573-qtsvg-5.15.diff
+++ b/recipes-qt/qt5/qtsvg/CVE-2023-32573-qtsvg-5.15.diff
@@ -1,0 +1,34 @@
+--- a/src/svg/qsvgfont_p.h
++++ b/src/svg/qsvgfont_p.h
+@@ -74,6 +74,7 @@ public:
+ class Q_SVG_PRIVATE_EXPORT QSvgFont : public QSvgRefCounted
+ {
+ public:
++    static constexpr qreal DEFAULT_UNITS_PER_EM = 1000;
+     QSvgFont(qreal horizAdvX);
+
+     void setFamilyName(const QString &name);
+@@ -86,9 +87,7 @@ public:
+     void draw(QPainter *p, const QPointF &point, const QString &str, qreal pixelSize, Qt::Alignment alignment) const;
+ public:
+     QString m_familyName;
+-    qreal m_unitsPerEm;
+-    qreal m_ascent;
+-    qreal m_descent;
++    qreal m_unitsPerEm = DEFAULT_UNITS_PER_EM;
+     qreal m_horizAdvX;
+     QHash<QChar, QSvgGlyph> m_glyphs;
+ };
+
+
+--- a/src/svg/qsvghandler.cpp
++++ b/src/svg/qsvghandler.cpp
+@@ -2668,7 +2668,7 @@ static bool parseFontFaceNode(QSvgStyleProperty *parent,
+
+     qreal unitsPerEm = toDouble(unitsPerEmStr);
+     if (!unitsPerEm)
+-        unitsPerEm = 1000;
++        unitsPerEm = QSvgFont::DEFAULT_UNITS_PER_EM;
+
+     if (!name.isEmpty())
+         font->setFamilyName(name);

--- a/recipes-qt/qt5/qtsvg/CVE-2023-32573-qtsvg-5.15.diff
+++ b/recipes-qt/qt5/qtsvg/CVE-2023-32573-qtsvg-5.15.diff
@@ -1,3 +1,17 @@
+From 9894206da35bde7025703f1e823f2df447ca200d Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marex@denx.de>
+Date: Tue, 10 Oct 2023 15:59:40 +0200
+Subject: [PATCH] qtsvg: Pick CVE-2023-32573 fix
+
+CVE: CVE-2023-32573
+Upstream-Status: Backport [https://download.qt.io/official_releases/qt/5.15/CVE-2023-32573-qtsvg-5.15.diff]
+---
+ src/svg/qsvgfont_p.h    | 5 ++---
+ src/svg/qsvghandler.cpp | 2 +-
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/src/svg/qsvgfont_p.h b/src/svg/qsvgfont_p.h
+index fd0a3fa..fcffbe8 100644
 --- a/src/svg/qsvgfont_p.h
 +++ b/src/svg/qsvgfont_p.h
 @@ -74,6 +74,7 @@ public:
@@ -6,7 +20,7 @@
  public:
 +    static constexpr qreal DEFAULT_UNITS_PER_EM = 1000;
      QSvgFont(qreal horizAdvX);
-
+ 
      void setFamilyName(const QString &name);
 @@ -86,9 +87,7 @@ public:
      void draw(QPainter *p, const QPointF &point, const QString &str, qreal pixelSize, Qt::Alignment alignment) const;
@@ -19,16 +33,16 @@
      qreal m_horizAdvX;
      QHash<QChar, QSvgGlyph> m_glyphs;
  };
-
-
+diff --git a/src/svg/qsvghandler.cpp b/src/svg/qsvghandler.cpp
+index b2227b6..f4a00e3 100644
 --- a/src/svg/qsvghandler.cpp
 +++ b/src/svg/qsvghandler.cpp
-@@ -2668,7 +2668,7 @@ static bool parseFontFaceNode(QSvgStyleProperty *parent,
-
+@@ -2666,7 +2666,7 @@ static bool parseFontFaceNode(QSvgStyleProperty *parent,
+ 
      qreal unitsPerEm = toDouble(unitsPerEmStr);
      if (!unitsPerEm)
 -        unitsPerEm = 1000;
 +        unitsPerEm = QSvgFont::DEFAULT_UNITS_PER_EM;
-
+ 
      if (!name.isEmpty())
          font->setFamilyName(name);

--- a/recipes-qt/qt5/qtsvg_git.bb
+++ b/recipes-qt/qt5/qtsvg_git.bb
@@ -13,3 +13,7 @@ LIC_FILES_CHKSUM = " \
 DEPENDS += "qtbase"
 
 SRCREV = "78ec450b81c403d3b4e6a2c178e300cef3637cca"
+
+SRC_URI += "\
+    file://CVE-2023-32573-qtsvg-5.15.diff \
+"


### PR DESCRIPTION
Pull in fixes for the following CVEs:

https://nvd.nist.gov/vuln/detail/CVE-2023-32573
https://nvd.nist.gov/vuln/detail/CVE-2023-32762
https://nvd.nist.gov/vuln/detail/CVE-2023-32763
https://nvd.nist.gov/vuln/detail/CVE-2023-33285
https://nvd.nist.gov/vuln/detail/CVE-2023-34410
https://nvd.nist.gov/vuln/detail/CVE-2023-37369
https://nvd.nist.gov/vuln/detail/CVE-2023-38197
https://nvd.nist.gov/vuln/detail/CVE-2023-43114

The patches all come from https://download.qt.io/official_releases/qt/5.15/ and are subsequently updated in separate commit using devtool .