### PR TITLE
conf/layer.conf: Add meta-oe to LAYERDEPENDS

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -27,7 +27,7 @@ BBFILE_PRIORITY_qt5-layer = "7"
 # cause compatibility issues with other layers
 LAYERVERSION_qt5-layer = "1"
 
-LAYERDEPENDS_qt5-layer = "core"
+LAYERDEPENDS_qt5-layer = "core openembedded-layer"
 
 LAYERSERIES_COMPAT_qt5-layer = "dunfell gatesgarth hardknott honister kirkstone langdale mickledore"
 


### PR DESCRIPTION
Layer meta-openembedded/meta-oe provides sip. It is required to avoid errors while building python3-pyqt5 which depends on sip, for example:

```
ERROR: Required build target 'python3-pyqt5' has no buildable providers.
Missing or unbuildable dependency chain was: ['python3-pyqt5', 'sip3-native']
```

It looks like a similar fix is required for branch master. If this pull request for Yocto release Kirkstone is approved I will test and create a similar pull request for master too.