### PR TITLE
[kirkstone+] examples: Update qt5-opengles2-test to most recent commit

### DIFF
--- a/recipes-qt/examples/qt5-opengles2-test_git.bb
+++ b/recipes-qt/examples/qt5-opengles2-test_git.bb
@@ -13,7 +13,7 @@ DEPENDS = "qtbase qtsensors"
 EXCLUDE_FROM_WORLD = "1"
 
 SRC_URI = "git://github.com/smk-embedded/qt5-opengles2-test.git;branch=master;protocol=https"
-SRCREV = "938390507054ed1258345f70ed55770d2fe56176"
+SRCREV = "293ae5cfedf48c97178057932d06db409117e4ad"
 S = "${WORKDIR}/git"
 
 inherit qmake5


### PR DESCRIPTION
This commit applies to kirkstone and onwards without problems.

Include minor fixes and improvements:
  293ae5c Add a timeout parameter
  9f160a9 Only define precision for OpenGL ES
  db70e81 Fix assertion failure on startup
  3653b2f Merge pull request #1 from sean-anderson-seco/qt5
  ee5f190 Avoid unused variable warning
  dcbf214 Cast doubles to floats explicitly
  2816b45 Include QOpenGLFunctions