### PR TITLE
qtbase: Pick CVE-2023-51714 fix

### DIFF
--- a/recipes-qt/qt5/qtbase/0001-CVE-2023-51714-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/0001-CVE-2023-51714-qtbase-5.15.diff
@@ -1,0 +1,38 @@
+From ea63c28efc1d2ecb467b83a34923d12462efa96f Mon Sep 17 00:00:00 2001
+From: Marc Mutz <marc.mutz@qt.io>
+Date: Tue, 12 Dec 2023 20:51:56 +0100
+Subject: [PATCH] HPack: fix a Yoda Condition
+
+Putting the variable on the LHS of a relational operation makes the
+expression easier to read. In this case, we find that the whole
+expression is nonsensical as an overflow protection, because if
+name.size() + value.size() overflows, the result will exactly _not_
+be > max() - 32, because UB will have happened.
+
+To be fixed in a follow-up commit.
+
+As a drive-by, add parentheses around the RHS.
+
+Change-Id: I35ce598884c37c51b74756b3bd2734b9aad63c09
+Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>
+(cherry picked from commit 658607a34ead214fbacbc2cca44915655c318ea9)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit 4f7efd41740107f90960116700e3134f5e433867)
+(cherry picked from commit 13c16b756900fe524f6d9534e8a07aa003c05e0c)
+(cherry picked from commit 1d4788a39668fb2dc5912a8d9c4272dc40e99f92)
+(cherry picked from commit 87de75b5cc946d196decaa6aef4792a6cac0b6db)
+---
+
+diff --git a/src/network/access/http2/hpacktable.cpp b/src/network/access/http2/hpacktable.cpp
+index 834214f..ab166a6 100644
+--- a/src/network/access/http2/hpacktable.cpp
++++ b/src/network/access/http2/hpacktable.cpp
+@@ -63,7 +63,7 @@
+     // 32 octets of overhead."
+ 
+     const unsigned sum = unsigned(name.size() + value.size());
+-    if (std::numeric_limits<unsigned>::max() - 32 < sum)
++    if (sum > (std::numeric_limits<unsigned>::max() - 32))
+         return HeaderSize();
+     return HeaderSize(true, quint32(sum + 32));
+ }

--- a/recipes-qt/qt5/qtbase/0002-CVE-2023-51714-qtbase-5.15.diff
+++ b/recipes-qt/qt5/qtbase/0002-CVE-2023-51714-qtbase-5.15.diff
@@ -1,0 +1,59 @@
+From 23c3fc483e8b6e21012a61f0bea884446f727776 Mon Sep 17 00:00:00 2001
+From: Marc Mutz <marc.mutz@qt.io>
+Date: Tue, 12 Dec 2023 22:08:07 +0100
+Subject: [PATCH] HPack: fix incorrect integer overflow check
+
+This code never worked:
+
+For the comparison with max() - 32 to trigger, on 32-bit platforms (or
+Qt 5) signed interger overflow would have had to happen in the
+addition of the two sizes. The compiler can therefore remove the
+overflow check as dead code.
+
+On Qt 6 and 64-bit platforms, the signed integer addition would be
+very unlikely to overflow, but the following truncation to uint32
+would yield the correct result only in a narrow 32-value window just
+below UINT_MAX, if even that.
+
+Fix by using the proper tool, qAddOverflow.
+
+Manual conflict resolutions:
+ - qAddOverflow doesn't exist in Qt 5, use private add_overflow
+   predecessor API instead
+
+Change-Id: I7599f2e75ff7f488077b0c60b81022591005661c
+Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>
+(cherry picked from commit ee5da1f2eaf8932aeca02ffea6e4c618585e29e3)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit debeb8878da2dc706ead04b6072ecbe7e5313860)
+Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+Reviewed-by: Marc Mutz <marc.mutz@qt.io>
+(cherry picked from commit 811b9eef6d08d929af8708adbf2a5effb0eb62d7)
+(cherry picked from commit f931facd077ce945f1e42eaa3bead208822d3e00)
+(cherry picked from commit 9ef4ca5ecfed771dab890856130e93ef5ceabef5)
+Reviewed-by: Mårten Nordheim <marten.nordheim@qt.io>
+---
+
+diff --git a/src/network/access/http2/hpacktable.cpp b/src/network/access/http2/hpacktable.cpp
+index ab166a6..de91fc0 100644
+--- a/src/network/access/http2/hpacktable.cpp
++++ b/src/network/access/http2/hpacktable.cpp
+@@ -40,6 +40,7 @@
+ #include "hpacktable_p.h"
+ 
+ #include <QtCore/qdebug.h>
++#include <QtCore/private/qnumeric_p.h>
+ 
+ #include <algorithm>
+ #include <cstddef>
+@@ -62,7 +63,9 @@
+     // for counting the number of references to the name and value would have
+     // 32 octets of overhead."
+ 
+-    const unsigned sum = unsigned(name.size() + value.size());
++    size_t sum;
++    if (add_overflow(size_t(name.size()), size_t(value.size()), &sum))
++        return HeaderSize();
+     if (sum > (std::numeric_limits<unsigned>::max() - 32))
+         return HeaderSize();
+     return HeaderSize(true, quint32(sum + 32));

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -46,6 +46,8 @@ SRC_URI += "\
     file://CVE-2023-38197-qtbase-5.15.diff \
     file://CVE-2023-43114-5.15.patch \
     file://0027-xkb-fix-build-with-libxkbcommon-1.6.0-and-later.patch \
+    file://0001-CVE-2023-51714-qtbase-5.15.diff \
+    file://0002-CVE-2023-51714-qtbase-5.15.diff \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with


### PR DESCRIPTION
An issue was discovered in the HTTP2 implementation in Qt before 5.15.17, 6.x before 6.2.11, 6.3.x through 6.5.x before 6.5.4, and 6.6.x before 6.6.2. network/access/http2/hpacktable.cpp has an incorrect HPack integer overflow check.

Advisory:
- https://nvd.nist.gov/vuln/detail/CVE-2023-51714

Patch:
- https://download.qt.io/official_releases/qt/5.15/0001-CVE-2023-51714-qtbase-5.15.diff
- https://download.qt.io/official_releases/qt/5.15/0002-CVE-2023-51714-qtbase-5.15.diff