### PR TITLE
qmake5: Move to EXPORT_FUNCTIONS

### DIFF
--- a/classes/qmake5.bbclass
+++ b/classes/qmake5.bbclass
@@ -6,14 +6,16 @@ inherit qmake5_base
 QT5TOOLSDEPENDS ?= "qtbase-native"
 DEPENDS:prepend = "${QT5TOOLSDEPENDS} "
 
-do_configure() {
+qmake5_do_configure() {
     qmake5_base_do_configure
 }
 
-do_install() {
+qmake5_do_install() {
     qmake5_base_do_install
 }
 
-do_install:class-native() {
+qmake5_do_install:class-native() {
     qmake5_base_native_do_install
 }
+
+EXPORT_FUNCTIONS do_configure do_install


### PR DESCRIPTION
A recent change in bitbake [1] has caused a build failure in qtwebkit. The fix with how the EXPORT_FUNCTIONS is being handled means that it is running into a collision with the explicit do_configure defined in this file.

This fix moves the explicit do_configure and do_insatll to use the EXPORT_FUNCTIONS methodology so that the conflict is resolved correctly.

[1] https://git.openembedded.org/bitbake/commit/?id=66306d5151acb0a26a171c338d8f60eb9eb16c6b