### PR TITLE
nativesdk-packagegroup-qt5-toolchain-host: Use inherit_defer for nativesdk

### DIFF
--- a/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
+++ b/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
@@ -3,7 +3,8 @@
 SUMMARY = "Host packages for the Qt5 standalone SDK or external toolchain"
 LICENSE = "MIT"
 
-inherit packagegroup nativesdk
+inherit packagegroup
+inherit_defer nativesdk
 
 PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"
 


### PR DESCRIPTION
Since packagegroup.bbclass is using inherit_defer in oe-core, some classes are now appearing after native resulting in QA errors

QA Issue: nativesdk-packagegroup-qt5-toolchain-host: native/nativesdk class is not inherited last, this can result in unexpected behaviour. Classes inherited after native/nativesdk: allarch.bbclass [native-last]

### Testing
- [x] `bitbake nativesdk-packagegroup-qt5-toolchain-host` succeeds and QA issue no longer occurs.