### PR TITLE
Reinstate LTS OE versions support

### DIFF
--- a/compat/legacy/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bbappend
+++ b/compat/legacy/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bbappend
@@ -1,0 +1,1 @@
+inherit nativesdk

--- a/compat/scarthgap/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bbappend
+++ b/compat/scarthgap/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bbappend
@@ -1,0 +1,1 @@
+inherit_defer nativesdk

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_qt5-layer = "1"
 
 LAYERDEPENDS_qt5-layer = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_qt5-layer = "dunfell gatesgarth hardknott honister kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_qt5-layer = "dunfell kirkstone scarthgap"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_qt5-layer = "1"
 
 LAYERDEPENDS_qt5-layer = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_qt5-layer = "scarthgap"
+LAYERSERIES_COMPAT_qt5-layer = "dunfell gatesgarth hardknott honister kirkstone langdale mickledore nanbield scarthgap"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -39,3 +39,6 @@ QT_GIT_PROJECT ?= "qt"
 QT_GIT ?= "git://code.qt.io/${QT_GIT_PROJECT}"
 QT_GIT_PROTOCOL ?= "git"
 QT_EDITION ?= "opensource"
+
+# Compatibility handling to support pre-Scarthgap OE releases.
+BBFILES += "${LAYERDIR}/compat/${@'scarthgap' if 'scarthgap' in d.getVar('LAYERSERIES_CORENAMES').split() else 'legacy'}/*/*/*.bbappend"

--- a/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
+++ b/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
@@ -4,7 +4,6 @@ SUMMARY = "Host packages for the Qt5 standalone SDK or external toolchain"
 LICENSE = "MIT"
 
 inherit packagegroup
-inherit_defer nativesdk
 
 PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"
 


### PR DESCRIPTION
Reinstate support for older OE releases by using inherit_defer only
for OE Scarthgap release, while retaining the old behavior for all
the recently supported older OE releases.

Keep support only for OE dunfell/kirkstone/scarthgap, the rest of
the releases which are EOL are still dropped.