### PR TITLE
layer.conf: update LAYERSERIES_COMPAT for styhead

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_qt5-layer = "1"
 
 LAYERDEPENDS_qt5-layer = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_qt5-layer = "dunfell gatesgarth hardknott honister kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_qt5-layer = "dunfell gatesgarth hardknott honister kirkstone langdale mickledore nanbield scarthgap styhead"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 


### PR DESCRIPTION
Dear maintainer.
oe-core's LAYERSERIES_COMPAT has been updated, so this layer's LAYERSERIES_COMPAT also needs to be updated.

oe-core switched to styhead in: https://git.openembedded.org/openembedded-core/commit?id=cef91ebeb3f2b1d41336fff60555064430a80397
