### PR TITLE
qt5: do not mix bitbake's shell variables

### DIFF
--- a/classes/qmake5_base.bbclass
+++ b/classes/qmake5_base.bbclass
@@ -50,7 +50,7 @@ inherit qmake5_paths
 
 generate_target_qt_config_file() {
     qtconf="$1"
-    cat > "${qtconf}" <<EOF
+    cat > "$qtconf" <<EOF
 [Paths]
 Prefix = ${OE_QMAKE_PATH_PREFIX}
 Headers = ${OE_QMAKE_PATH_HEADERS}
@@ -220,9 +220,9 @@ qmake5_base_fix_install() {
         rm -rf ${D}${STAGING_PATH}
         # remove empty dirs
         TMP=`dirname ${D}${STAGING_PATH}`
-        while test ${TMP} != ${D}; do
-            rmdir ${TMP}
-            TMP=`dirname ${TMP}`;
+        while test $TMP != ${D}; do
+            rmdir $TMP
+            TMP=`dirname $TMP`;
         done
     fi
 }

--- a/recipes-python/pyqt5/python3-pyqt5_5.15.10.bb
+++ b/recipes-python/pyqt5/python3-pyqt5_5.15.10.bb
@@ -41,17 +41,16 @@ PYQT_MODULES = " \
 "
 
 do_configure:prepend() {
-    local i
-    local extra_args
+    extra_args=""
 
     cd ${S}
 
     for i in ${DISABLED_FEATURES}; do
-        extra_args="${extra_args} --disabled-feature=${i}"
+        extra_args="$extra_args --disabled-feature=$i"
     done
 
     for i in ${PYQT_MODULES}; do
-        extra_args="${extra_args} --enable=${i}"
+        extra_args="$extra_args --enable=$i"
     done
 
     sip-build \
@@ -67,7 +66,7 @@ do_configure:prepend() {
         --enable=Qt \
         --enable=QtCore \
         --no-dbus-python \
-        ${extra_args}
+        $extra_args
 
     QMAKE_PROFILES=${B}/PyQt5.pro
 }

--- a/recipes-qt/qt5/ptest/run-ptest
+++ b/recipes-qt/qt5/ptest/run-ptest
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 for x in ` awk '{print $1}' tst_list `;do
-    ./${x};
+    ./$x;
 done
 

--- a/recipes-qt/qt5/qt5-ptest.inc
+++ b/recipes-qt/qt5/qt5-ptest.inc
@@ -19,8 +19,8 @@ fakeroot do_install_ptest() {
     t=${D}${PTEST_PATH}
     for var in ` find ${B}/tests/auto/ -name tst_*`; do
         if [ -z ` echo ${var##*/} | grep '\.'` ]; then
-            echo ${var##*/} >> ${t}/tst_list
-            install -m 0744  ${var} ${t}
+            echo ${var##*/} >> $t/tst_list
+            install -m 0744 $var $t
         fi
     done
 }

--- a/recipes-qt/qt5/qtdeclarative_git.bb
+++ b/recipes-qt/qt5/qtdeclarative_git.bb
@@ -32,17 +32,17 @@ EXTRA_QMAKEVARS_CONFIGURE += "${PACKAGECONFIG_CONFARGS}"
 do_install_ptest() {
     mkdir -p ${D}${PTEST_PATH}
     for var in `find ${B}/tests/auto/ -name tst_*`; do
-        case=$(basename ${var})
-        if [ -z `echo ${case} | grep '\.'` ]; then
-            dname=$(dirname ${var})
-            pdir=$(basename ${dname})
-            echo ${pdir}/${case} >> ${D}${PTEST_PATH}/tst_list
+        case=$(basename $var)
+        if [ -z `echo $case | grep '\.'` ]; then
+            dname=$(dirname $var)
+            pdir=$(basename $dname)
+            echo $pdir/$case >> ${D}${PTEST_PATH}/tst_list
 
-            mkdir ${D}${PTEST_PATH}/${pdir}
-            install -m 0744 ${var} ${D}${PTEST_PATH}/${pdir}
-            data_dir=${S}/${dname##${B}}/data
-            if [ -d ${data_dir} ]; then
-                cp -r ${data_dir} ${D}${PTEST_PATH}/${pdir}
+            mkdir ${D}${PTEST_PATH}/$pdir
+            install -m 0744 $var ${D}${PTEST_PATH}/$pdir
+            ddir=${S}/${dname##${B}}/data
+            if [ -d $ddir ]; then
+                cp -r $ddir ${D}${PTEST_PATH}/$pdir
             fi
         fi
     done


### PR DESCRIPTION
- do not use `${}` in nested shell functions to mix bitbake's shell variables
- git rid of `local` which is not a POSIX variant
    
Signed-off-by: Valek Andrej <andrej.v@skyrain.eu>