### PR TITLE
use UNPACKDIR

### DIFF
--- a/compat/legacy/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bbappend
+++ b/compat/legacy/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bbappend
@@ -1,1 +1,0 @@
-inherit nativesdk

--- a/compat/scarthgap/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bbappend
+++ b/compat/scarthgap/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bbappend
@@ -1,1 +1,0 @@
-inherit_defer nativesdk

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_qt5-layer = "1"
 
 LAYERDEPENDS_qt5-layer = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_qt5-layer = "dunfell gatesgarth hardknott honister kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_qt5-layer = "styhead"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -39,6 +39,3 @@ QT_GIT_PROJECT ?= "qt"
 QT_GIT ?= "git://code.qt.io/${QT_GIT_PROJECT}"
 QT_GIT_PROTOCOL ?= "git"
 QT_EDITION ?= "opensource"
-
-# Compatibility handling to support pre-Scarthgap OE releases.
-BBFILES += "${LAYERDIR}/compat/${@'scarthgap' if 'scarthgap' in d.getVar('LAYERSERIES_CORENAMES').split() else 'legacy'}/*/*/*.bbappend"

--- a/recipes-python/pyqt5/python3-pyqt-builder-native_1.16.0.bb
+++ b/recipes-python/pyqt5/python3-pyqt-builder-native_1.16.0.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://pyproject.toml;md5=62537c8c9cf72be020148e3adc658ce3;b
 
 SRC_URI[sha256sum] = "47bbd2cfa5430020108f9f40301e166cbea98b6ef3e53953350bdd4c6b31ab18"
 
-inherit pypi ${@'setuptools3' if (d.getVar('LAYERSERIES_CORENAMES') in ["dunfell"]) else 'python_setuptools_build_meta'} native
+inherit pypi python_setuptools_build_meta native
 
 PYPI_PACKAGE = "PyQt-builder"
 

--- a/recipes-qt/demo-extrafiles/qt5-demo-extrafiles.bb
+++ b/recipes-qt/demo-extrafiles/qt5-demo-extrafiles.bb
@@ -1,7 +1,9 @@
 DESCRIPTION = "Extra files for qt5 demo"
 LICENSE = "LGPL-2.0-only"
-S="${WORKDIR}"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=88355dc91a186cc816d9f64757793895"
+
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 SRC_URI += "file://cinematicexperience.desktop \
             file://cinematicexperience.png \
@@ -38,32 +40,32 @@ inherit allarch
 do_install () {
     install -d ${D}/${datadir}/pixmaps
     install -d ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/cinematicexperience.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/cinematicexperience.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/hellogl_es2.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/hellogl_es2.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/hellowindow.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/hellowindow.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/qt5everywheredemo.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/qt5everywheredemo.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/qt5nmapcarousedemo.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/qt5nmapcarousedemo.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/qt5nmapper.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/qt5nmapper.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/qtledbillboard.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/qtledbillboard.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/qtledcombo.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/qtledcombo.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/qtsmarthome.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/qtsmarthome.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/quitbattery.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/quitbattery.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/quitindicators.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/quitindicators.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/qt5basket.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/qt5basket.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/qt5nesting.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/qt5nesting.desktop ${D}/${datadir}/applications
-    install -m 0644 ${WORKDIR}/qt5solarsystem.png ${D}/${datadir}/pixmaps
-    install -m 0644 ${WORKDIR}/qt5solarsystem.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/cinematicexperience.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/cinematicexperience.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/hellogl_es2.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/hellogl_es2.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/hellowindow.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/hellowindow.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/qt5everywheredemo.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/qt5everywheredemo.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/qt5nmapcarousedemo.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/qt5nmapcarousedemo.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/qt5nmapper.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/qt5nmapper.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/qtledbillboard.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/qtledbillboard.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/qtledcombo.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/qtledcombo.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/qtsmarthome.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/qtsmarthome.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/quitbattery.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/quitbattery.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/quitindicators.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/quitindicators.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/qt5basket.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/qt5basket.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/qt5nesting.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/qt5nesting.desktop ${D}/${datadir}/applications
+    install -m 0644 ${UNPACKDIR}/qt5solarsystem.png ${D}/${datadir}/pixmaps
+    install -m 0644 ${UNPACKDIR}/qt5solarsystem.desktop ${D}/${datadir}/applications
 }

--- a/recipes-qt/maliit/maliit-framework-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-framework-qt5_git.bb
@@ -72,7 +72,7 @@ do_install:append() {
     sed -i -e "s|/usr|${STAGING_DIR_TARGET}${prefix}|" ${D}/${OE_QMAKE_PATH_QT_ARCHDATA}/mkspecs/features/maliit-plugins.prf
 
     install -d ${D}${datadir}/applications
-    install -m 644 ${WORKDIR}/maliit-server.desktop ${D}${datadir}/applications
+    install -m 644 ${UNPACKDIR}/maliit-server.desktop ${D}${datadir}/applications
 }
 
 pkg_postinst_ontarget:${PN} () {

--- a/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
+++ b/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
@@ -4,6 +4,7 @@ SUMMARY = "Host packages for the Qt5 standalone SDK or external toolchain"
 LICENSE = "MIT"
 
 inherit packagegroup
+inherit_defer nativesdk
 
 PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"
 

--- a/recipes-qt/qt-kiosk-browser/qt-kiosk-browser_git.bb
+++ b/recipes-qt/qt-kiosk-browser/qt-kiosk-browser_git.bb
@@ -24,7 +24,7 @@ inherit qmake5
 EXTRA_QMAKEVARS_PRE += "PREFIX=${prefix}"
 
 do_install:append() {
-    install -Dm 0644 ${WORKDIR}/${PN}.conf ${D}${sysconfdir}/${PN}.conf
+    install -Dm 0644 ${UNPACKDIR}/${PN}.conf ${D}${sysconfdir}/${PN}.conf
 }
 
 RDEPENDS:${PN} += " \

--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -161,7 +161,7 @@ do_install() {
 
     # Install CMake's toolchain configuration
     mkdir -p ${D}${datadir}/cmake/OEToolchainConfig.cmake.d/
-    install -m 644 ${WORKDIR}/OEQt5Toolchain.cmake ${D}${datadir}/cmake/OEToolchainConfig.cmake.d/
+    install -m 644 ${UNPACKDIR}/OEQt5Toolchain.cmake ${D}${datadir}/cmake/OEToolchainConfig.cmake.d/
 
     # Fix up absolute paths in scripts
     sed -i -e '1s,#!/usr/bin/python,#! ${USRBINPATH}/env python,' \


### PR DESCRIPTION
refs:  https://lists.openembedded.org/g/openembedded-architecture/message/2007

fixes:
ERROR: /tmp/test/meta-qt5/recipes-qt/demo-extrafiles/qt5-demo-extrafiles.bb: Using S = ${WORKDIR} is no longer supported

and
install: cannot stat 'build/tmp/work/all-poky-linux/qt5-demo-extrafiles/1.0/cinematicexperience.png': No such file or directory
...

