### PR TITLE
ptest: skip buildpaths QA tests for ptest packages

### DIFF
--- a/recipes-qt/qt5/qtdeclarative_git.bb
+++ b/recipes-qt/qt5/qtdeclarative_git.bb
@@ -62,3 +62,4 @@ do_install:append() {
 SRCREV = "abe4729ea8db32124c36dc33fc32eb629df03043"
 
 BBCLASSEXTEND =+ "native nativesdk"
+INSANE_SKIP:${PN}-ptest += "buildpaths"

--- a/recipes-qt/qt5/qtxmlpatterns_git.bb
+++ b/recipes-qt/qt5/qtxmlpatterns_git.bb
@@ -28,3 +28,5 @@ EXTRA_QMAKEVARS_PRE += "${@bb.utils.contains('PACKAGECONFIG', 'qtdeclarative', '
 SRCREV = "43996a4e543fa22b345c03ba3a1a41b1aba4b454"
 
 BBCLASSEXTEND =+ "native nativesdk"
+
+INSANE_SKIP:${PN}-ptest += "buildpaths"


### PR DESCRIPTION
Skip the QA tests on failing modules until tests can be fixed.

Recently, I have been very troubled by this issue. Seeing that Qt6 handles it this way, temporarily adopted the same approach in Qt5 as well.

https://code.qt.io/cgit/yocto/meta-qt6.git/commit/recipes-qt/qt6/qtdeclarative_git.bb?id=39560e55667b6e8e2f971d040697f084eb936b1d