### PR TITLE
layer.conf: Update for the walnascar release series

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_qt5-layer = "1"
 
 LAYERDEPENDS_qt5-layer = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_qt5-layer = "styhead"
+LAYERSERIES_COMPAT_qt5-layer = "styhead walnascar"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 


### PR DESCRIPTION
OE-core master dropped styhead from LAYERSERIES_CORENAMES.