### PR TITLE
qtbase: update buildmachine fixup paths to honor QT_DIR_NAME

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -300,7 +300,7 @@ do_install:append() {
 
     # Remove references to buildmachine paths in examples target files if examples feature is enabled
     if ${@bb.utils.contains('PACKAGECONFIG', 'examples', 'true', 'false', d)}; then
-        sed -i -e "s:${B}:${prefix}:g" ${D}${datadir}/examples/widgets/tools/plugandpaint/plugins/libpnp_basictools.prl
+        sed -i -e "s:${B}:${prefix}:g" ${D}${OE_QMAKE_PATH_EXAMPLES}/widgets/tools/plugandpaint/plugins/libpnp_basictools.prl
     fi
 }
 

--- a/recipes-qt/qt5/qtdeclarative_git.bb
+++ b/recipes-qt/qt5/qtdeclarative_git.bb
@@ -56,7 +56,7 @@ do_install:append:class-nativesdk() {
 do_install:append() {
     # Remove references to buildmachine paths
     qtversion=$(echo ${PV} | cut -d+ -f1)
-    sed -i -e "s:${S}::g" ${D}${includedir}/QtQml/$qtversion/QtQml/private/qqmljsparser_p.h
+    sed -i -e "s:${S}::g" ${D}${OE_QMAKE_PATH_HEADERS}/QtQml/$qtversion/QtQml/private/qqmljsparser_p.h
 }
 
 SRCREV = "abe4729ea8db32124c36dc33fc32eb629df03043"


### PR DESCRIPTION
Commit "qtbase: Remove references to buildmachine paths" (6fe2990d) and a few other related commits need to consider the case where QT_DIR_NAME is set.

Fix these paths to use the OE_QMAKE_PATH_* variables that contain the QT_DIR_NAME.