### PR TITLE
nativesdk-qtbase: Fix TMPDIR leak

### DIFF
--- a/recipes-qt/qt5/nativesdk-qtbase_git.bb
+++ b/recipes-qt/qt5/nativesdk-qtbase_git.bb
@@ -55,6 +55,7 @@ SRC_URI += "\
 SRC_URI += " \
     file://0023-Always-build-uic-and-qvkgen.patch \
     file://0024-Avoid-renameeat2-for-native-sdk-builds.patch \
+    file://0028-Remove-host-paths-from-qmake.patch \
 "
 
 # CMake's toolchain configuration of nativesdk-qtbase


### PR DESCRIPTION
This fixes a QA issue where the path to TMPDIR was leaked in the qmake binary. We already apply this in qtbase, it seems to just be missing from the nativesdk variant.