### PR TITLE
qtwebengine: disable linker GCS warning on aarch64

### DIFF
--- a/recipes-qt/qt5/qtwebengine_git.bb
+++ b/recipes-qt/qt5/qtwebengine_git.bb
@@ -84,6 +84,8 @@ COMPATIBLE_MACHINE:armv7a = "(.*)"
 COMPATIBLE_MACHINE:armv7ve = "(.*)"
 COMPATIBLE_MACHINE:aarch64 = "(.*)"
 
+LDFLAGS:append:aarch64 = " -Wl,-z,gcs-report-dynamic=none"
+
 inherit qmake5
 inherit gettext
 inherit perlnative


### PR DESCRIPTION
This PR aims to solve https://github.com/meta-qt5/meta-qt5/issues/609