### PR TITLE
layer.conf: Update for the whinlatter release series

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_qt5-layer = "1"
 
 LAYERDEPENDS_qt5-layer = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_qt5-layer = "styhead walnascar"
+LAYERSERIES_COMPAT_qt5-layer = "whinlatter"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 


### PR DESCRIPTION
OE core layers switched layerseries to whinlatter due to potential disruptions caused by WORKDIR -> UNPACKDIR changes.