### PR TITLE
whinlatter release + UNPACK and 'S =' changes

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_qt5-layer = "1"
 
 LAYERDEPENDS_qt5-layer = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_qt5-layer = "styhead walnascar"
+LAYERSERIES_COMPAT_qt5-layer = "whinlatter"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 

--- a/recipes-connectivity/libconnman-qt/libconnman-qt5_git.bb
+++ b/recipes-connectivity/libconnman-qt/libconnman-qt5_git.bb
@@ -12,7 +12,6 @@ PV = "${VERSION}+git${SRCPV}"
 SRCREV = "6786936cba9048ee943c0cd5d051c0b8fc70896f"
 SRC_URI = "git://github.com/sailfishos/libconnman-qt.git;protocol=https;branch=master"
 
-S = "${WORKDIR}/git"
 
 inherit pkgconfig
 

--- a/recipes-connectivity/libqofono/libqofono_git.bb
+++ b/recipes-connectivity/libqofono/libqofono_git.bb
@@ -10,7 +10,6 @@ SRCREV = "047b667f18ca73cb7f884f174d1d164a616d6814"
 SRC_URI = "git://github.com/sailfishos/libqofono.git;protocol=https;branch=master \
            file://0001-also-emit-modemRemoved-and-modemAdded.patch \
 "
-S = "${WORKDIR}/git"
 
 PV = "0.103+gitr${SRCPV}"
 

--- a/recipes-connectivity/libqofono/libqofonoext_git.bb
+++ b/recipes-connectivity/libqofono/libqofonoext_git.bb
@@ -7,7 +7,6 @@ DEPENDS += "qtbase qtdeclarative qtxmlpatterns libqofono"
 
 SRCREV = "ebe45e0fe46578c24e9fe241e84cd5ca0f097372"
 SRC_URI = "git://github.com/sailfishos/libqofonoext.git;protocol=https;branch=master"
-S = "${WORKDIR}/git"
 
 PV = "1.027+gitr${SRCPV}"
 

--- a/recipes-connectivity/libvcard/libvcard_git.bb
+++ b/recipes-connectivity/libvcard/libvcard_git.bb
@@ -10,6 +10,5 @@ SRC_URI = "git://github.com/pol51/libvcard.git;protocol=https;branch=master"
 
 PV = "1.0+gitr${SRCPV}"
 
-S = "${WORKDIR}/git"
 
 inherit cmake_qt5

--- a/recipes-python/pyqt5/python3-pyqt5.inc
+++ b/recipes-python/pyqt5/python3-pyqt5.inc
@@ -9,7 +9,7 @@ inherit pypi python3-dir python3native qmake5 qmake5_paths
 SRC_URI[sha256sum] = "d46b7804b1b10a4ff91753f8113e5b5580d2b4462f3226288e2d84497334898a"
 PYPI_PACKAGE = "PyQt5"
 
-S = "${WORKDIR}/PyQt5-${PV}"
+S = "${UNPACKDIR}/PyQt5-${PV}"
 
 python() {
     if 'meta-python' not in d.getVar('BBFILE_COLLECTIONS').split():

--- a/recipes-python/pyqtchart/python3-pyqtchart_5.15.1.bb
+++ b/recipes-python/pyqtchart/python3-pyqtchart_5.15.1.bb
@@ -14,7 +14,7 @@ PYPI_PACKAGE = "PyQtChart"
 SRC_URI[md5sum] = "8a36bc796b0d9a2301e613c382336b0e"
 SRC_URI[sha256sum] = "8d976b3dbfb233fb0123129323c68adb9d3693c945bba1e227e004208f0747bc"
 
-S = "${WORKDIR}/PyQtChart-${PV}"
+S = "${UNPACKDIR}/PyQtChart-${PV}"
 
 inherit qmake5
 inherit python3native python3-dir

--- a/recipes-qt/demo-extrafiles/qt5-demo-extrafiles.bb
+++ b/recipes-qt/demo-extrafiles/qt5-demo-extrafiles.bb
@@ -2,8 +2,7 @@ DESCRIPTION = "Extra files for qt5 demo"
 LICENSE = "LGPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=88355dc91a186cc816d9f64757793895"
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}/sources"
 
 SRC_URI += "file://cinematicexperience.desktop \
             file://cinematicexperience.png \

--- a/recipes-qt/examples/cinematicexperience_1.0.bb
+++ b/recipes-qt/examples/cinematicexperience_1.0.bb
@@ -10,13 +10,13 @@ SRC_URI += "file://fix_qt5_3_compatibility.patch"
 SRC_URI[md5sum] = "935a5db0a6b2a72c67236e72f52be7d1"
 SRC_URI[sha256sum] = "0dd602983ced5f7c0cfd5ad0fbfe2b0b7e3c9ff715e4ef23eef818ccc2b6c60b"
 
-S = "${WORKDIR}/Qt5_CinematicExperience_rpi_${PV}"
+S = "${UNPACKDIR}/Qt5_CinematicExperience_rpi_${PV}"
 
 # other version available for small screens
 #SRC_URI = "http://quitcoding.com/download/Qt5_CinematicExperience_1.0.tgz"
 #SRC_URI[md5sum] = "1c4f9bf5411c985fc5d3dbfc5d826a29"
 #SRC_URI[sha256sum] = "0e547e0259667915a24e84ade5efdcd0c553f81786734452c2c8dbce19a19f44"
-#S = "${WORKDIR}/Qt5_CinematicExperience_${PV}/"
+#S = "${UNPACKDIR}/Qt5_CinematicExperience_${PV}/"
 
 DEPENDS = "qtdeclarative qtgraphicaleffects"
 RDEPENDS:${PN} = "liberation-fonts qtdeclarative-qmlplugins qtgraphicaleffects-qmlplugins"

--- a/recipes-qt/examples/qt5-opengles2-test_git.bb
+++ b/recipes-qt/examples/qt5-opengles2-test_git.bb
@@ -14,6 +14,5 @@ EXCLUDE_FROM_WORLD = "1"
 
 SRC_URI = "git://github.com/smk-embedded/qt5-opengles2-test.git;branch=master;protocol=https"
 SRCREV = "293ae5cfedf48c97178057932d06db409117e4ad"
-S = "${WORKDIR}/git"
 
 inherit qmake5

--- a/recipes-qt/examples/qt5everywheredemo_1.0.bb
+++ b/recipes-qt/examples/qt5everywheredemo_1.0.bb
@@ -11,7 +11,7 @@ QT_GIT_PROJECT = "qt-labs"
 QT_MODULE_BRANCH = "master"
 SRC_URI = "${QT_GIT}/qt5-everywhere-demo;branch=${QT_MODULE_BRANCH};protocol=${QT_GIT_PROTOCOL}"
 
-S = "${WORKDIR}/git/QtDemo"
+S = "${UNPACKDIR}/git/QtDemo"
 
 require recipes-qt/qt5/qt5.inc
 

--- a/recipes-qt/examples/qt5ledscreen_1.0.bb
+++ b/recipes-qt/examples/qt5ledscreen_1.0.bb
@@ -10,7 +10,7 @@ SRC_URI = "http://quitcoding.com/download/ledscreen_1.0.tgz"
 SRC_URI[md5sum] = "8fc482d5a8b16f43f022c9a282f305b8"
 SRC_URI[sha256sum] = "fa4759b70a5fa148a901a3f9a659f7bd2503d73774022012bded880dffa0d15c"
 
-S = "${WORKDIR}/ledscreen_1.0"
+S = "${UNPACKDIR}/ledscreen_1.0"
 
 do_install() {
     install -d ${D}${datadir}/${P}

--- a/recipes-qt/examples/qt5nmapcarousedemo_1.0.bb
+++ b/recipes-qt/examples/qt5nmapcarousedemo_1.0.bb
@@ -10,7 +10,7 @@ SRC_URI = "http://quitcoding.com/download/Qt5_NMap_CarouselDemo_1.0.tgz"
 SRC_URI[md5sum] = "c1b4568cdbb6b3af4ca10c5a90aa8128"
 SRC_URI[sha256sum] = "445da212074a10a432f4508d125814212bbe7a967bfa47b015b92dfac6bfd65f"
 
-S = "${WORKDIR}/Qt5_NMap_CarouselDemo_1.0"
+S = "${UNPACKDIR}/Qt5_NMap_CarouselDemo_1.0"
 
 require recipes-qt/qt5/qt5.inc
 

--- a/recipes-qt/examples/qt5nmapper_1.0.bb
+++ b/recipes-qt/examples/qt5nmapper_1.0.bb
@@ -11,7 +11,7 @@ SRC_URI = "http://quitcoding.com/download/Qt5_NMapper_1.0.tgz \
 SRC_URI[md5sum] = "dafc425280144d8e286788e75a0dba0f"
 SRC_URI[sha256sum] = "607fbf4c448f00d3c563f9ef8a582bcb6e8fe550e80b56bf8d9127a417faa53b"
 
-S = "${WORKDIR}/Qt5_NMapper_1.0"
+S = "${UNPACKDIR}/Qt5_NMapper_1.0"
 
 require recipes-qt/qt5/qt5.inc
 

--- a/recipes-qt/examples/qtsmarthome_1.0.bb
+++ b/recipes-qt/examples/qtsmarthome_1.0.bb
@@ -11,7 +11,7 @@ SRC_URI = "https://artifacts.toradex.com/artifactory/tdxref-oe-prod-frankfurt/du
 SRC_URI[md5sum] = "883b0376239baec20ebec072e938a995"
 SRC_URI[sha256sum] = "fceaa813c33e462bad6c0383eaef81a6f6e586c15d1fa73898173b517fc1cda6"
 
-S = "${WORKDIR}/smarthome_src"
+S = "${UNPACKDIR}/smarthome_src"
 
 require recipes-qt/qt5/qt5.inc
 

--- a/recipes-qt/examples/quitbattery_1.0.0.bb
+++ b/recipes-qt/examples/quitbattery_1.0.0.bb
@@ -10,7 +10,7 @@ SRC_URI = "http://quitcoding.com/download/QUItBattery_1.0.0.tar.gz"
 SRC_URI[md5sum] = "7c7babc1086491b116b01d154b6163fd"
 SRC_URI[sha256sum] = "38dcb7630553c397f9d8a53c6411b1a6237956ed8dd4859e01487b1dd8f37873"
 
-S = "${WORKDIR}/QUItBattery_1.0.0"
+S = "${UNPACKDIR}/QUItBattery_1.0.0"
 
 require recipes-qt/qt5/qt5.inc
 

--- a/recipes-qt/examples/quitindicators_1.0.1.bb
+++ b/recipes-qt/examples/quitindicators_1.0.1.bb
@@ -9,7 +9,7 @@ SRC_URI = "http://quitcoding.com/download/QUItIndicators_1.0.1.tar.gz"
 SRC_URI[md5sum] = "85ec60b553e181c55b331a9921d1b9a0"
 SRC_URI[sha256sum] = "db84112adbde9b6f28c129e8fb37a6912f4bc34bed18e57f570fb78ea0cb6ae2"
 
-S = "${WORKDIR}/QUItIndicators_1.0.1"
+S = "${UNPACKDIR}/QUItIndicators_1.0.1"
 
 require recipes-qt/qt5/qt5.inc
 

--- a/recipes-qt/maliit/maliit-framework-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-framework-qt5_git.bb
@@ -93,7 +93,6 @@ if [ "x$D" = "x" ]; then
 fi
 }
 
-S = "${WORKDIR}/git"
 
 # http://errors.yoctoproject.org/Errors/Details/852835/
 # ERROR: QA Issue: File /usr/lib/mkspecs/features/maliit-framework.prf in package maliit-framework-qt5-dev contains reference to TMPDIR [buildpaths]

--- a/recipes-qt/maliit/maliit-plugins-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-plugins-qt5_git.bb
@@ -35,6 +35,5 @@ FILES:${PN} += "\
     ${datadir} \
 "
 
-S = "${WORKDIR}/git"
 
 EXTRA_OEMAKE += "INSTALL_ROOT=${D}"

--- a/recipes-qt/qmllive/qmllive_git.bb
+++ b/recipes-qt/qmllive/qmllive_git.bb
@@ -11,7 +11,6 @@ SRC_URI = "${QT_GIT}/qmllive.git;branch=dev \
            file://0001-lib.pro-Append-LIB_ARCH-to-lib.patch \
           "
 SRCREV = "0c7bf141b08aa9e757e91a4a05769257d043eab2"
-S = "${WORKDIR}/git"
 
 inherit pkgconfig qmake5
 

--- a/recipes-qt/qsiv/qsiv_1.1.bb
+++ b/recipes-qt/qsiv/qsiv_1.1.bb
@@ -7,7 +7,6 @@ DEPENDS = "qtdeclarative"
 SRCREV = "7b9810b0f02f9ac74fae3ead6e2e9fb5c1382173"
 SRC_URI = "git://code.ossystems.io/qt/qsiv;protocol=https;branch=master"
 
-S = "${WORKDIR}/git"
 
 inherit qmake5
 

--- a/recipes-qt/qt-kiosk-browser/qt-kiosk-browser_git.bb
+++ b/recipes-qt/qt-kiosk-browser/qt-kiosk-browser_git.bb
@@ -13,7 +13,6 @@ SRC_URI = " \
 PV = "0.0+git${SRCPV}"
 SRCREV = "d42b7d9050b5445e2b9430022a46d5d583581631"
 
-S = "${WORKDIR}/git"
 
 inherit qmake5
 

--- a/recipes-qt/qt5/qt5-creator_git.bb
+++ b/recipes-qt/qt5/qt5-creator_git.bb
@@ -29,7 +29,6 @@ SRC_URI = " \
 "
 SRC_URI:append:libc-musl = " file://0001-Link-with-libexecinfo-on-musl.patch"
 
-S = "${WORKDIR}/git"
 
 EXTRA_QMAKEVARS_PRE += " \
     IDE_LIBRARY_BASENAME=${baselib}${QT_DIR_NAME} \

--- a/recipes-qt/qt5/qt5-git.inc
+++ b/recipes-qt/qt5/qt5-git.inc
@@ -12,6 +12,5 @@ SRC_URI = " \
 
 CVE_PRODUCT:append = " qt"
 
-S = "${WORKDIR}/git"
 
 PV = "5.15.16+git${SRCPV}"

--- a/recipes-qt/qt5/qt5-plugin-generic-vboxtouch_git.bb
+++ b/recipes-qt/qt5/qt5-plugin-generic-vboxtouch_git.bb
@@ -21,7 +21,7 @@ SRC_URI = "git://github.com/nemomobile/qt5-plugin-generic-vboxtouch.git;branch=m
            file://0001-include-errno.h-for-errno-definition.patch;patchdir=.. \
            "
 SRCREV = "3f2bdb5a1d346f02d5ab185522271ba2288a42bb"
-S = "${WORKDIR}/git/vboxtouch"
+S = "${UNPACKDIR}/git/vboxtouch"
 
 inherit qmake5
 

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -312,7 +312,7 @@ PACKAGE_PREPROCESS_FUNCS += "${@bb.utils.contains('PACKAGECONFIG', 'tests', 'qt_
 
 qt_package_preprocess_examples () {
     # Remove references to buildmachine paths in the comment headers of the examples source files
-    sed -i -e 's:${WORKDIR}::g' \
+    sed -i -e 's:${UNPACKDIR}::g' \
         ${B}/examples/dbus/chat/chat_interface.cpp \
         ${B}/examples/dbus/chat/chat_interface.h \
         ${B}/examples/dbus/chat/chat_adaptor.cpp \
@@ -325,7 +325,7 @@ qt_package_preprocess_examples () {
 
 qt_package_preprocess_tests () {
     # Remove references to buildmachine paths in the comment headers of the tests source files
-    sed -i -e 's:${WORKDIR}::g' \
+    sed -i -e 's:${UNPACKDIR}::g' \
         ${B}/tests/auto/dbus/qdbusabstractinterface/qdbusabstractinterface/pinger_interface.h \
         ${B}/tests/auto/dbus/qdbusabstractinterface/qdbusabstractinterface/pinger_interface.cpp
 }

--- a/recipes-qt/qt5/qtlocation_git.bb
+++ b/recipes-qt/qt5/qtlocation_git.bb
@@ -46,7 +46,7 @@ PACKAGE_PREPROCESS_FUNCS += "qtlocation_package_preprocess"
 
 qtlocation_package_preprocess () {
     # Remove references to buildmachine paths in the comment headers of the examples source files
-    sed -i -e 's:${WORKDIR}::g' \
+    sed -i -e 's:${UNPACKDIR}::g' \
         ${B}/src/plugins/position/geoclue/geoclue_interface.cpp \
         ${B}/src/plugins/position/geoclue/master_interface.cpp \
         ${B}/src/plugins/position/geoclue/satellite_interface.h \

--- a/recipes-qt/qtchooser/qtchooser_git.bb
+++ b/recipes-qt/qtchooser/qtchooser_git.bb
@@ -8,7 +8,6 @@ LIC_FILES_CHKSUM = " \
     file://LICENSE.GPL;md5=d32239bcb673463ab874e80d47fae504 \
     file://LICENSE.LGPL;md5=4193e7f1d47a858f6b7c0f1ee66161de \
 "
-S = "${WORKDIR}/git"
 SRCREV = "71750df4f0c6bbadcd422cdf7fe360ad033bbd14"
 PV = "39+git${SRCPV}"
 

--- a/recipes-qt/qwt/qwt-qt5_6.1.5.bb
+++ b/recipes-qt/qwt/qwt-qt5_6.1.5.bb
@@ -19,7 +19,7 @@ SRC_URI = " \
 "
 SRC_URI[qwt.sha256sum] = "4076de63ec2b5e84379ddfebf27c7b29b8dc9074f3db7e2ca61d11a1d8adc041"
 
-S = "${WORKDIR}/qwt-${PV}"
+S = "${UNPACKDIR}/qwt-${PV}"
 
 EXTRA_QMAKEVARS_PRE += " \
     QWT_CONFIG+=QwtPkgConfig \

--- a/recipes-qt/tufao/tufao_1.3.10.bb
+++ b/recipes-qt/tufao/tufao_1.3.10.bb
@@ -12,7 +12,6 @@ SRC_URI = "git://github.com/vinipsmaker/tufao.git;protocol=http;branch=1.x;proto
 # This includes bugfixes from 1.x branch
 PV:append = "+${SRCPV}"
 
-S = "${WORKDIR}/git"
 
 inherit cmake_qt5
 


### PR DESCRIPTION
It was related to latest UNPACKDIR changes -> https://git.openembedded.org/openembedded-core/commit/?id=46480a5e66747a673041fe4452a0ab14a1736d5e

* sed -i "/^S = \"\${WORKDIR}\/git\"/d" `find . -name *.bb -o -name *.inc -o -name *.bbclass`
* sed -i "s/^S = \"\${WORKDIR}\//S = \"\${UNPACKDIR}\//g" `find . -name *.bb -o -name *.inc -o -name *.bbclass`
* some manual tweaking


Question: is it okay to have only 'whinlatter'  in the compat list?