### PR TITLE
Enable pyqt5 configs for ROS rqt use case

### DIFF
--- a/recipes-python/pyqt5/python3-pyqt5_5.15.10.bb
+++ b/recipes-python/pyqt5/python3-pyqt5_5.15.10.bb
@@ -4,7 +4,10 @@ PYQT_MODULES += " \
     QtNetwork \
     QtQml \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'QtQuick QtWidgets QtQuickWidgets', '', d)} \
+    QtSvg \
 "
+
+DEPENDS += "qtsvg"
 
 do_compile:prepend() {
     for pro_file in $(find ${B} -name "*.pro"); do

--- a/recipes-qt/qt5/qtbase-native_git.bb
+++ b/recipes-qt/qt5/qtbase-native_git.bb
@@ -61,7 +61,7 @@ CLEANBROKEN = "1"
 XPLATFORM:toolchain-clang = "linux-oe-clang"
 XPLATFORM ?= "linux-oe-g++"
 
-PACKAGECONFIG ?= ""
+PACKAGECONFIG ?= "gui"
 PACKAGECONFIG[gui] = "-gui -qpa offscreen,-no-gui,"
 PACKAGECONFIG[imageformats] = "-qt-libpng -qt-libjpeg -gif -ico, -no-libpng -no-libjpeg -no-ico -no-gif,"
 PACKAGECONFIG[openssl] = "-openssl,-no-openssl,openssl"


### PR DESCRIPTION
Enable the Qt gui module in qtbase-native and the QtSvg module in pyqt5 by default. This allows building and running the ROS rqt application.