### PR TITLE
qtbase: Add qtwayland as recommended dependency

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -307,7 +307,10 @@ do_install:append() {
 # mkspecs have mac specific scripts that depend on perl and bash
 INSANE_SKIP:${PN}-mkspecs += "file-rdeps"
 
-RRECOMMENDS:${PN}-plugins += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'libx11-locale', '', d)}"
+RRECOMMENDS:${PN}-plugins += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'libx11-locale', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'qtwayland', '', d)} \
+"
 
 TARGET_MKSPEC ?= "linux-g++"
 


### PR DESCRIPTION
Add qtwayland to RRECOMMENDS for qtbase-plugins when wayland is in DISTRO_FEATURES. This ensures the Qt wayland platform plugin is automatically installed in images that include Qt, avoiding the runtime error "Could not find the Qt platform plugin wayland".