### PR TITLE
qtbase: add -fno-char8_t to fix build with C++20 char8_t change

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -194,6 +194,7 @@ QT_CONFIG_FLAGS_GOLD = "-no-use-gold-linker"
 LDFLAGS:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', ' -fuse-ld=bfd ', '', d)}"
 
 LDFLAGS:append:riscv64 = " -pthread"
+CXXFLAGS:append:class-target = " -fno-char8_t"
 
 QT_CONFIG_FLAGS += " \
     ${QT_CONFIG_FLAGS_GOLD} \


### PR DESCRIPTION
qtbase: disable char8_t in C++20 to fix test build error

The test tst_qcborstreamwriter.cpp uses u8 string literals which in
C++20 have type 'const char8_t*' instead of 'const char*', causing
compilation errors with GCC 15:

  error: invalid conversion from 'const char8_t*' to 'const char*'

Add '-fno-char8_t' to CXXFLAGS for the target build to revert the u8
literal type to 'const char*' and maintain compatibility with the
existing Qt 5.15 code, without forcing an older C++ standard.

Modified:
  CXXFLAGS:append:class-target = " -fno-char8_t"