### PR TITLE
python3-pyqt5-sip: bump 12.13.0 -> 12.18.0

### DIFF
--- a/recipes-python/pyqt5/python3-pyqt5-sip_12.18.0.bb
+++ b/recipes-python/pyqt5/python3-pyqt5-sip_12.18.0.bb
@@ -1,13 +1,15 @@
 SUMMARY = "The sip module support for PyQt5"
 HOMEPAGE = "https://pypi.org/project/PyQt5-sip/"
-LICENSE = "SIP | GPL-2.0-or-later"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=9cd437778ebd1c056a76b4ded73b3a6d"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=bc996f4e03c98eae60de43496026f863"
 
-SRC_URI[sha256sum] = "7f321daf84b9c9dbca61b80e1ef37bdaffc0e93312edae2cd7da25b953971d91"
+PYPI_SRC_URI = "https://files.pythonhosted.org/packages/f3/31/5ef342de9faee0f3801088946ae103db9b9eaeba3d6a64fefd5ce74df244/pyqt5_sip-${PV}.tar.gz"
+SRC_URI[sha256sum] = "71c37db75a0664325de149f43e2a712ec5fa1f90429a21dafbca005cb6767f94"
 
 inherit pypi setuptools3
 
 PYPI_PACKAGE = "PyQt5_sip"
+S = "${UNPACKDIR}/pyqt5_sip-${PV}"
 
 # Fix build with gcc-14
 # http://errors.yoctoproject.org/Errors/Details/761512/


### PR DESCRIPTION
Fixes the build against Python 3.14.

Two packaging changes upstream since 12.13.0:

- The pypi.bbclass source URL 404s for this release; pinned the actual hash-path URL from PyPI's file listing instead.
- Tarball's internal directory is lowercase (pyqt5_sip-12.18.0), unlike the PYPI_PACKAGE-derived default.

License-Update: Relicensed as BSD 2-Clause [https://github.com/Python-SIP/sip/commit/f32039b07c47280039dcdcd0f8a2b1323fda912e]