### PR TITLE
qtchooser: fix LICENSE expression syntax error

### DIFF
--- a/recipes-qt/qtchooser/qtchooser_git.bb
+++ b/recipes-qt/qtchooser/qtchooser_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Wrapper to select between Qt development binary versions"
 HOMEPAGE = "http://macieira.org/qtchooser"
-LICENSE = "LGPL-2.1-only & Digia-Qt-LGPL-Exception-1.1 | GPL-3.0-only"
+LICENSE = "LGPL-2.1-only WITH Digia-Qt-LGPL-exception-1.1 OR GPL-3.0-only"
 SRC_URI = "git://code.qt.io/qtsdk/qtchooser.git;branch=master"
 
 LIC_FILES_CHKSUM = " \


### PR DESCRIPTION
This fixes the following build issue:

```
ERROR: /layers/meta-qt5/recipes-qt/qtchooser/qtchooser_git.bb: QA Issue: qtchooser: LICENSE value has an invalid format:
ERROR:15: Unexpected 'AND'
LGPL-2.1-only  AND  Digia-Qt-LGPL-Exception-1.1  OR  GPL-3.0-only
```

This should not be backported.