### PR TITLE
qtlocation: run sed when geoclue/geoclue2 directories exist

### DIFF
--- a/recipes-qt/qt5/qtlocation_git.bb
+++ b/recipes-qt/qt5/qtlocation_git.bb
@@ -46,23 +46,28 @@ PACKAGE_PREPROCESS_FUNCS += "qtlocation_package_preprocess"
 
 qtlocation_package_preprocess () {
     # Remove references to buildmachine paths in the comment headers of the examples source files
-    sed -i -e 's:${S}::g' \
-        ${B}/src/plugins/position/geoclue/geoclue_interface.cpp \
-        ${B}/src/plugins/position/geoclue/master_interface.cpp \
-        ${B}/src/plugins/position/geoclue/satellite_interface.h \
-        ${B}/src/plugins/position/geoclue/geoclue_interface.h \
-        ${B}/src/plugins/position/geoclue/position_interface.cpp \
-        ${B}/src/plugins/position/geoclue/masterclient_interface.h \
-        ${B}/src/plugins/position/geoclue/velocity_interface.h \
-        ${B}/src/plugins/position/geoclue/master_interface.h \
-        ${B}/src/plugins/position/geoclue/position_interface.h \
-        ${B}/src/plugins/position/geoclue/satellite_interface.cpp \
-        ${B}/src/plugins/position/geoclue/velocity_interface.cpp \
-        ${B}/src/plugins/position/geoclue/masterclient_interface.cpp \
-        ${B}/src/plugins/position/geoclue2/location_interface.h \
-        ${B}/src/plugins/position/geoclue2/manager_interface.h \
-        ${B}/src/plugins/position/geoclue2/client_interface.cpp \
-        ${B}/src/plugins/position/geoclue2/client_interface.h \
-        ${B}/src/plugins/position/geoclue2/manager_interface.cpp \
-        ${B}/src/plugins/position/geoclue2/location_interface.cpp
+    if [ -d "${B}/src/plugins/position/geoclue" ]; then
+        sed -i -e 's:${S}::g' \
+            ${B}/src/plugins/position/geoclue/geoclue_interface.cpp \
+            ${B}/src/plugins/position/geoclue/master_interface.cpp \
+            ${B}/src/plugins/position/geoclue/satellite_interface.h \
+            ${B}/src/plugins/position/geoclue/geoclue_interface.h \
+            ${B}/src/plugins/position/geoclue/position_interface.cpp \
+            ${B}/src/plugins/position/geoclue/masterclient_interface.h \
+            ${B}/src/plugins/position/geoclue/velocity_interface.h \
+            ${B}/src/plugins/position/geoclue/master_interface.h \
+            ${B}/src/plugins/position/geoclue/position_interface.h \
+            ${B}/src/plugins/position/geoclue/satellite_interface.cpp \
+            ${B}/src/plugins/position/geoclue/velocity_interface.cpp \
+            ${B}/src/plugins/position/geoclue/masterclient_interface.cpp
+    fi
+    if [ -d "${B}/src/plugins/position/geoclue2" ]; then
+        sed -i -e 's:${S}::g' \
+            ${B}/src/plugins/position/geoclue2/location_interface.h \
+            ${B}/src/plugins/position/geoclue2/manager_interface.h \
+            ${B}/src/plugins/position/geoclue2/client_interface.cpp \
+            ${B}/src/plugins/position/geoclue2/client_interface.h \
+            ${B}/src/plugins/position/geoclue2/manager_interface.cpp \
+            ${B}/src/plugins/position/geoclue2/location_interface.cpp
+    fi
 }


### PR DESCRIPTION
When qtbase is built without dbus in its PACKAGECONFIG definition, those two directories are not deployed, because these lines in src/plugins/position/position.pro:
```
  linux|freebsd|openbsd|netbsd:qtHaveModule(dbus):SUBDIRS += geoclue
  linux|freebsd|openbsd|netbsd:qtHaveModule(dbus):SUBDIRS += geoclue2
```
Since we can't read another recipe's PACKAGECONFIG, check for the existence of those directories before sed'ing to avoid the following error:
```
| DEBUG: Executing shell function qtlocation_package_preprocess | sed: can't read .../build/src/plugins/position/geoclue/geoclue_interface.cpp: No such file or directory | [...]
| sed: can't read .../build/src/plugins/position/geoclue2/location_interface.h: No such file or directory | [...]
| WARNING: exit code 2 from a shell command.
```

**NOTE:** If accepted, can this be backported to the wrynose branch? Commit can be cherry-picked without conflicts as of writing this.