### PR TITLE
qtdeclarative: fix a buildpaths issue

### DIFF
--- a/recipes-qt/qt5/qtdeclarative_git.bb
+++ b/recipes-qt/qt5/qtdeclarative_git.bb
@@ -64,3 +64,12 @@ SRCREV = "abe4729ea8db32124c36dc33fc32eb629df03043"
 
 BBCLASSEXTEND =+ "native nativesdk"
 INSANE_SKIP:${PN}-ptest += "buildpaths"
+
+qtdeclarative_strip_buildpaths() {
+    # Remove references to buildmachine paths in the comment headers of the examples source files
+    if [ -f "${B}/src/qmldevtools/qqmljsparser.cpp" ]; then
+        sed -i -e 's:${S}::g' "${B}/src/qmldevtools/qqmljsparser.cpp"
+    fi
+}
+
+PACKAGE_PREPROCESS_FUNCS += "qtdeclarative_strip_buildpaths"


### PR DESCRIPTION
Similar to the qtlocation recipe, strip out build paths from source files to fix a do_package_qa error:

  ERROR: qtdeclarative-5.15.16+git-r0 do_package_qa: QA Issue: File
  /usr/src/debug/qtdeclarative/5.15.16+git/src/qmldevtools/qqmljsparser.cpp
  in package qtdeclarative-src contains reference to TMPDIR [buildpaths]

This seems to be the only problematic file:

  $ pwd
  .../packages-split/qtdeclarative-src
  $ grep --files-with-matches --recursive 'tmp/work/cortexa7t2hf-neon-imx-oe-linux-gnueabi'
  usr/src/debug/qtdeclarative/5.15.16+git/src/qmldevtools/qqmljsparser.cpp

---

Note: applies for the wrynose branch, I will open another PR for wrynose if this is accepted.